### PR TITLE
Guard modal initialization across scripts

### DIFF
--- a/app/static/js/config.js
+++ b/app/static/js/config.js
@@ -18,38 +18,39 @@ import { CURRENCIES } from './constants.js';
 document.addEventListener('DOMContentLoaded', () => {
   const tbody = document.querySelector('#account-table tbody');
   const modalEl = document.getElementById('accountModal');
-  const accModal = new bootstrap.Modal(modalEl);
+  const accModal = window.bootstrap && modalEl ? new bootstrap.Modal(modalEl) : null;
   const form = document.getElementById('account-form');
   const addBtn = document.getElementById('add-account');
   const alertBox = document.getElementById('acc-alert');
-  const currencySelect = form.currency;
-  const idField = form.querySelector('input[name="id"]');
-  const colorInput = form.querySelector('input[name="color"]');
+  const currencySelect = form?.currency;
+  const idField = form?.querySelector('input[name="id"]');
+  const colorInput = form?.querySelector('input[name="color"]');
   const colorBtn = document.getElementById('color-btn');
-  const modalTitle = modalEl.querySelector('.modal-title');
+  const modalTitle = modalEl?.querySelector('.modal-title');
   let accounts = [];
   const confirmEl = document.getElementById('confirmModal');
-  const confirmModal = new bootstrap.Modal(confirmEl);
-  const confirmMessage = confirmEl.querySelector('#confirm-message');
-  const confirmBtn = confirmEl.querySelector('#confirm-yes');
+  const confirmModal = window.bootstrap && confirmEl ? new bootstrap.Modal(confirmEl) : null;
+  const confirmMessage = confirmEl?.querySelector('#confirm-message');
+  const confirmBtn = confirmEl?.querySelector('#confirm-yes');
   let accountToDelete = null;
 
   const freqTbody = document.querySelector('#freq-table tbody');
   const freqModalEl = document.getElementById('freqModal');
-  const freqModal = new bootstrap.Modal(freqModalEl);
+  const freqModal = window.bootstrap && freqModalEl ? new bootstrap.Modal(freqModalEl) : null;
   const freqForm = document.getElementById('freq-form');
   const addFreqBtn = document.getElementById('add-freq');
   const freqAlertBox = document.getElementById('freq-alert');
-  const freqIdField = freqForm.querySelector('input[name="id"]');
-  const freqModalTitle = freqModalEl.querySelector('.modal-title');
+  const freqIdField = freqForm?.querySelector('input[name="id"]');
+  const freqModalTitle = freqModalEl?.querySelector('.modal-title');
   const freqConfirmEl = document.getElementById('confirmFreqModal');
-  const freqConfirmModal = new bootstrap.Modal(freqConfirmEl);
-  const freqConfirmMessage = freqConfirmEl.querySelector('#confirm-freq-message');
-  const freqConfirmBtn = freqConfirmEl.querySelector('#confirm-freq-yes');
+  const freqConfirmModal = window.bootstrap && freqConfirmEl ? new bootstrap.Modal(freqConfirmEl) : null;
+  const freqConfirmMessage = freqConfirmEl?.querySelector('#confirm-freq-message');
+  const freqConfirmBtn = freqConfirmEl?.querySelector('#confirm-freq-yes');
   let freqToDelete = null;
   let frequents = [];
 
   function populateCurrencies() {
+    if (!currencySelect) return;
     currencySelect.innerHTML = '';
     CURRENCIES.forEach(c => {
       const opt = document.createElement('option');
@@ -59,29 +60,33 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  addBtn.addEventListener('click', async () => {
-    form.reset();
-    populateCurrencies();
-    idField.value = '';
-    alertBox.classList.add('d-none');
-    colorInput.value = '#000000';
-    colorBtn.style.color = '#000000';
-    modalTitle.textContent = 'Nueva cuenta';
-    accModal.show();
-  });
+  if (addBtn && accModal) {
+    addBtn.addEventListener('click', async () => {
+      form?.reset();
+      populateCurrencies();
+      if (idField) idField.value = '';
+      alertBox?.classList.add('d-none');
+      if (colorInput) colorInput.value = '#000000';
+      if (colorBtn) colorBtn.style.color = '#000000';
+      if (modalTitle) modalTitle.textContent = 'Nueva cuenta';
+      accModal.show();
+    });
+  }
 
-  colorBtn.addEventListener('click', () => {
+  colorBtn?.addEventListener('click', () => {
     const rect = colorBtn.getBoundingClientRect();
-    colorInput.style.left = `${rect.left}px`;
-    colorInput.style.top = `${rect.bottom}px`;
-    colorInput.click();
+    if (colorInput) {
+      colorInput.style.left = `${rect.left}px`;
+      colorInput.style.top = `${rect.bottom}px`;
+      colorInput.click();
+    }
   });
 
-  colorInput.addEventListener('input', e => {
-    colorBtn.style.color = e.target.value;
+  colorInput?.addEventListener('input', e => {
+    if (colorBtn) colorBtn.style.color = e.target.value;
   });
 
-  form.addEventListener('submit', async e => {
+  form?.addEventListener('submit', async e => {
     e.preventDefault();
     if (!form.reportValidity()) return;
     const data = new FormData(form);
@@ -94,65 +99,68 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     showOverlay();
     let result;
-    if (idField.value) {
+    if (idField?.value) {
       result = await updateAccount(idField.value, payload);
     } else {
       result = await createAccount(payload);
     }
     hideOverlay();
-    alertBox.classList.remove('d-none', 'alert-success', 'alert-danger');
+    alertBox?.classList.remove('d-none', 'alert-success', 'alert-danger');
     if (result.ok) {
-      alertBox.classList.add('alert-success');
-      alertBox.textContent = 'Cuenta guardada';
-      if (result.account && !idField.value) {
-        idField.value = result.account.id;
+      alertBox?.classList.add('alert-success');
+      if (alertBox) alertBox.textContent = 'Cuenta guardada';
+      if (result.account && !idField?.value) {
+        if (idField) idField.value = result.account.id;
       }
-      tbody.innerHTML = '';
+      if (tbody) tbody.innerHTML = '';
       await loadAccounts();
-      accModal.hide();
+      accModal?.hide();
     } else {
-      alertBox.classList.add('alert-danger');
-      alertBox.textContent = result.error || 'Error al guardar';
+      alertBox?.classList.add('alert-danger');
+      if (alertBox) alertBox.textContent = result.error || 'Error al guardar';
     }
 
   });
 
   async function loadAccounts() {
     accounts = await fetchAccounts();
+    if (!tbody) return;
     accounts.forEach(acc => {
       renderAccount(tbody, acc, startEdit, removeAccount);
     });
   }
 
   async function startEdit(acc) {
+    if (!form || !accModal) return;
     form.reset();
     populateCurrencies();
     form.name.value = acc.name;
     form.currency.value = acc.currency;
     form.opening_balance.value = acc.opening_balance;
-    idField.value = acc.id;
+    if (idField) idField.value = acc.id;
     const color = acc.color || '#000000';
-    colorInput.value = color;
-    colorBtn.style.color = color;
-    alertBox.classList.add('d-none');
-    modalTitle.textContent = 'Editar cuenta';
+    if (colorInput) colorInput.value = color;
+    if (colorBtn) colorBtn.style.color = color;
+    alertBox?.classList.add('d-none');
+    if (modalTitle) modalTitle.textContent = 'Editar cuenta';
     accModal.show();
   }
 
   async function removeAccount(acc) {
+    if (!confirmModal || !confirmMessage) return;
     accountToDelete = acc;
     confirmMessage.textContent = `¿Eliminar cuenta "${acc.name}"?`;
     confirmModal.show();
   }
 
-  confirmBtn.addEventListener('click', async () => {
+  confirmBtn?.addEventListener('click', async () => {
     if (!accountToDelete) return;
-    confirmModal.hide();
+    confirmModal?.hide();
     showOverlay();
     const result = await deleteAccount(accountToDelete.id);
     hideOverlay();
     if (result.ok) {
-      tbody.innerHTML = '';
+      if (tbody) tbody.innerHTML = '';
       await loadAccounts();
     } else {
       alert(result.error || 'Error al eliminar');
@@ -160,15 +168,17 @@ document.addEventListener('DOMContentLoaded', () => {
     accountToDelete = null;
   });
 
-  addFreqBtn.addEventListener('click', () => {
-    freqForm.reset();
-    freqIdField.value = '';
-    freqAlertBox.classList.add('d-none');
-    freqModalTitle.textContent = 'Nueva transacción frecuente';
-    freqModal.show();
-  });
+  if (addFreqBtn && freqModal) {
+    addFreqBtn.addEventListener('click', () => {
+      freqForm?.reset();
+      if (freqIdField) freqIdField.value = '';
+      freqAlertBox?.classList.add('d-none');
+      if (freqModalTitle) freqModalTitle.textContent = 'Nueva transacción frecuente';
+      freqModal.show();
+    });
+  }
 
-  freqForm.addEventListener('submit', async e => {
+  freqForm?.addEventListener('submit', async e => {
     e.preventDefault();
     if (!freqForm.reportValidity()) return;
     const data = new FormData(freqForm);
@@ -177,27 +187,28 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     showOverlay();
     let result;
-    if (freqIdField.value) {
+    if (freqIdField?.value) {
       result = await updateFrequent(freqIdField.value, payload);
     } else {
       result = await createFrequent(payload);
     }
     hideOverlay();
-    freqAlertBox.classList.remove('d-none', 'alert-success', 'alert-danger');
+    freqAlertBox?.classList.remove('d-none', 'alert-success', 'alert-danger');
     if (result.ok) {
-      freqAlertBox.classList.add('alert-success');
-      freqAlertBox.textContent = 'Frecuente guardado';
-      freqTbody.innerHTML = '';
+      freqAlertBox?.classList.add('alert-success');
+      if (freqAlertBox) freqAlertBox.textContent = 'Frecuente guardado';
+      if (freqTbody) freqTbody.innerHTML = '';
       await loadFrequents();
-      freqModal.hide();
+      freqModal?.hide();
     } else {
-      freqAlertBox.classList.add('alert-danger');
-      freqAlertBox.textContent = result.error || 'Error al guardar';
+      freqAlertBox?.classList.add('alert-danger');
+      if (freqAlertBox) freqAlertBox.textContent = result.error || 'Error al guardar';
     }
   });
 
   async function loadFrequents() {
     frequents = await fetchFrequents();
+    if (!freqTbody) return;
     freqTbody.innerHTML = '';
     frequents.forEach(freq => {
       renderFrequent(freqTbody, freq, startEditFreq, removeFreq);
@@ -205,27 +216,29 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function startEditFreq(freq) {
+    if (!freqForm || !freqModal) return;
     freqForm.reset();
     freqForm.description.value = freq.description;
-    freqIdField.value = freq.id;
-    freqAlertBox.classList.add('d-none');
-    freqModalTitle.textContent = 'Editar transacción frecuente';
+    if (freqIdField) freqIdField.value = freq.id;
+    freqAlertBox?.classList.add('d-none');
+    if (freqModalTitle) freqModalTitle.textContent = 'Editar transacción frecuente';
     freqModal.show();
   }
   async function removeFreq(freq) {
+    if (!freqConfirmModal || !freqConfirmMessage) return;
     freqToDelete = freq;
     freqConfirmMessage.textContent = `¿Eliminar transacción frecuente "${freq.description}"?`;
     freqConfirmModal.show();
   }
 
-  freqConfirmBtn.addEventListener('click', async () => {
+  freqConfirmBtn?.addEventListener('click', async () => {
     if (!freqToDelete) return;
-    freqConfirmModal.hide();
+    freqConfirmModal?.hide();
     showOverlay();
     const result = await deleteFrequent(freqToDelete.id);
     hideOverlay();
     if (result.ok) {
-      freqTbody.innerHTML = '';
+      if (freqTbody) freqTbody.innerHTML = '';
       await loadFrequents();
     } else {
       alert(result.error || 'Error al eliminar');
@@ -233,6 +246,9 @@ document.addEventListener('DOMContentLoaded', () => {
     freqToDelete = null;
   });
 
-  loadAccounts().then(() => loadFrequents());
+  const loaders = [];
+  if (tbody) loaders.push(loadAccounts());
+  if (freqTbody) loaders.push(loadFrequents());
+  Promise.all(loaders);
 });
 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1,199 +1,207 @@
 import { fetchAccounts, fetchTransactions, createTransaction, fetchFrequents } from './api.js';
 import { renderTransaction, populateAccounts, showOverlay, hideOverlay } from './ui.js';
 
-const tbody = document.querySelector('#tx-table tbody');
-const container = document.getElementById('table-container');
-const modalEl = document.getElementById('txModal');
-const txModal = new bootstrap.Modal(modalEl);
-const form = document.getElementById('tx-form');
-const alertBox = document.getElementById('tx-alert');
-const searchBox = document.getElementById('search-box');
-const headers = document.querySelectorAll('#tx-table thead th.sortable');
-const freqCheck = document.getElementById('freq-check');
-const freqSelect = document.getElementById('freq-select');
-const descInput = document.getElementById('desc-input');
+document.addEventListener('DOMContentLoaded', () => {
+  const tbody = document.querySelector('#tx-table tbody');
+  const container = document.getElementById('table-container');
+  const modalEl = document.getElementById('txModal');
+  const txModal = window.bootstrap && modalEl ? new bootstrap.Modal(modalEl) : null;
+  const form = document.getElementById('tx-form');
+  const alertBox = document.getElementById('tx-alert');
+  const searchBox = document.getElementById('search-box');
+  const headers = document.querySelectorAll('#tx-table thead th.sortable');
+  const freqCheck = document.getElementById('freq-check');
+  const freqSelect = document.getElementById('freq-select');
+  const descInput = document.getElementById('desc-input');
 
-let offset = 0;
-const limit = 50;
-let loading = false;
-let accounts = [];
-let accountMap = {};
-let transactions = [];
-let sortColumn = 0;
-let sortAsc = false;
-let frequents = [];
-let frequentMap = {};
+  let offset = 0;
+  const limit = 50;
+  let loading = false;
+  let accounts = [];
+  let accountMap = {};
+  let transactions = [];
+  let sortColumn = 0;
+  let sortAsc = false;
+  let frequents = [];
+  let frequentMap = {};
 
-function renderTransactions() {
-  const q = searchBox.value.trim().toLowerCase();
-  const filtered = transactions.filter(tx => {
-    const accName = accountMap[tx.account_id]?.name.toLowerCase() || '';
-    return tx.description.toLowerCase().includes(q) || accName.includes(q);
-  });
-  filtered.sort((a, b) => {
-    switch (sortColumn) {
-      case 0:
-        return sortAsc
-          ? new Date(a.date) - new Date(b.date)
-          : new Date(b.date) - new Date(a.date);
-      case 1:
-        return sortAsc
-          ? a.description.localeCompare(b.description)
-          : b.description.localeCompare(a.description);
-      case 2:
-        return sortAsc ? a.amount - b.amount : b.amount - a.amount;
-      case 3:
-        const accA = accountMap[a.account_id]?.name || '';
-        const accB = accountMap[b.account_id]?.name || '';
-        return sortAsc ? accA.localeCompare(accB) : accB.localeCompare(accA);
-      default:
-        return 0;
-    }
-  });
-  tbody.innerHTML = '';
-  filtered.forEach(tx => renderTransaction(tbody, tx, accountMap));
-}
-
-async function loadMore() {
-  if (loading) return;
-  loading = true;
-  const data = await fetchTransactions(limit, offset);
-  transactions = transactions.concat(data);
-  offset += data.length;
-  renderTransactions();
-  loading = false;
-}
-
-function openModal(type) {
-  form.reset();
-  document.getElementById('form-title').textContent = type === 'income' ? 'Nuevo Ingreso' : 'Nuevo Egreso';
-  populateAccounts(form.account_id, accounts.filter(a => a.is_active));
-  form.dataset.type = type;
-  alertBox.classList.add('d-none');
-  const today = new Date().toISOString().split('T')[0];
-  form.date.max = today;
-  form.date.value = today;
-  freqCheck.checked = false;
-  descInput.classList.remove('d-none');
-  freqSelect.classList.add('d-none');
-  txModal.show();
-}
-
-document.getElementById('add-income').addEventListener('click', () => openModal('income'));
-document.getElementById('add-expense').addEventListener('click', () => openModal('expense'));
-searchBox.addEventListener('input', renderTransactions);
-freqCheck.addEventListener('change', () => {
-  if (freqCheck.checked) {
-    populateFreqSelect();
-    descInput.classList.add('d-none');
-    freqSelect.classList.remove('d-none');
-    if (freqSelect.value) {
-      applyFrequent(frequentMap[freqSelect.value]);
-    }
-  } else {
-    descInput.classList.remove('d-none');
-    freqSelect.classList.add('d-none');
+  function renderTransactions() {
+    if (!searchBox || !tbody) return;
+    const q = searchBox.value.trim().toLowerCase();
+    const filtered = transactions.filter(tx => {
+      const accName = accountMap[tx.account_id]?.name.toLowerCase() || '';
+      return tx.description.toLowerCase().includes(q) || accName.includes(q);
+    });
+    filtered.sort((a, b) => {
+      switch (sortColumn) {
+        case 0:
+          return sortAsc
+            ? new Date(a.date) - new Date(b.date)
+            : new Date(b.date) - new Date(a.date);
+        case 1:
+          return sortAsc
+            ? a.description.localeCompare(b.description)
+            : b.description.localeCompare(a.description);
+        case 2:
+          return sortAsc ? a.amount - b.amount : b.amount - a.amount;
+        case 3:
+          const accA = accountMap[a.account_id]?.name || '';
+          const accB = accountMap[b.account_id]?.name || '';
+          return sortAsc ? accA.localeCompare(accB) : accB.localeCompare(accA);
+        default:
+          return 0;
+      }
+    });
+    tbody.innerHTML = '';
+    filtered.forEach(tx => renderTransaction(tbody, tx, accountMap));
   }
-});
 
-freqSelect.addEventListener('change', () => {
-  const f = frequentMap[freqSelect.value];
-  if (f) applyFrequent(f);
-});
-
-function populateFreqSelect() {
-  freqSelect.innerHTML = '';
-  frequents.forEach(f => {
-    const opt = document.createElement('option');
-    opt.value = f.id;
-    opt.textContent = f.description;
-    freqSelect.appendChild(opt);
-  });
-}
-
-function applyFrequent(f) {
-  if (!f) return;
-  descInput.value = f.description;
-}
-
-headers.forEach((th, index) => {
-  th.addEventListener('click', () => {
-    if (sortColumn === index) {
-      sortAsc = !sortAsc;
-    } else {
-      sortColumn = index;
-      sortAsc = true;
-    }
-    updateSortIcons();
+  async function loadMore() {
+    if (loading || !tbody) return;
+    loading = true;
+    const data = await fetchTransactions(limit, offset);
+    transactions = transactions.concat(data);
+    offset += data.length;
     renderTransactions();
-  });
-});
+    loading = false;
+  }
 
-function updateSortIcons() {
-  headers.forEach((th, index) => {
-    const icon = th.querySelector('.sort-icon');
-    if (!icon) return;
-    icon.classList.remove('bi-arrow-up', 'bi-arrow-down', 'bi-arrow-down-up');
-    if (index === sortColumn) {
-      icon.classList.add(sortAsc ? 'bi-arrow-up' : 'bi-arrow-down');
+  function openModal(type) {
+    if (!form || !txModal) return;
+    form.reset();
+    const titleEl = document.getElementById('form-title');
+    if (titleEl) titleEl.textContent = type === 'income' ? 'Nuevo Ingreso' : 'Nuevo Egreso';
+    populateAccounts(form.account_id, accounts.filter(a => a.is_active));
+    form.dataset.type = type;
+    alertBox?.classList.add('d-none');
+    const today = new Date().toISOString().split('T')[0];
+    form.date.max = today;
+    form.date.value = today;
+    freqCheck?.checked = false;
+    descInput?.classList.remove('d-none');
+    freqSelect?.classList.add('d-none');
+    txModal.show();
+  }
+
+  document.getElementById('add-income')?.addEventListener('click', () => openModal('income'));
+  document.getElementById('add-expense')?.addEventListener('click', () => openModal('expense'));
+  searchBox?.addEventListener('input', renderTransactions);
+  freqCheck?.addEventListener('change', () => {
+    if (freqCheck.checked) {
+      populateFreqSelect();
+      descInput?.classList.add('d-none');
+      freqSelect?.classList.remove('d-none');
+      if (freqSelect?.value) {
+        applyFrequent(frequentMap[freqSelect.value]);
+      }
     } else {
-      icon.classList.add('bi-arrow-down-up');
+      descInput?.classList.remove('d-none');
+      freqSelect?.classList.add('d-none');
     }
   });
-}
 
-container.addEventListener('scroll', () => {
-  if (container.scrollTop + container.clientHeight >= container.scrollHeight - 10) {
-    loadMore();
+  freqSelect?.addEventListener('change', () => {
+    const f = frequentMap[freqSelect.value];
+    if (f) applyFrequent(f);
+  });
+
+  function populateFreqSelect() {
+    if (!freqSelect) return;
+    freqSelect.innerHTML = '';
+    frequents.forEach(f => {
+      const opt = document.createElement('option');
+      opt.value = f.id;
+      opt.textContent = f.description;
+      freqSelect.appendChild(opt);
+    });
+  }
+
+  function applyFrequent(f) {
+    if (!f || !descInput) return;
+    descInput.value = f.description;
+  }
+
+  headers.forEach((th, index) => {
+    th.addEventListener('click', () => {
+      if (sortColumn === index) {
+        sortAsc = !sortAsc;
+      } else {
+        sortColumn = index;
+        sortAsc = true;
+      }
+      updateSortIcons();
+      renderTransactions();
+    });
+  });
+
+  function updateSortIcons() {
+    headers.forEach((th, index) => {
+      const icon = th.querySelector('.sort-icon');
+      if (!icon) return;
+      icon.classList.remove('bi-arrow-up', 'bi-arrow-down', 'bi-arrow-down-up');
+      if (index === sortColumn) {
+        icon.classList.add(sortAsc ? 'bi-arrow-up' : 'bi-arrow-down');
+      } else {
+        icon.classList.add('bi-arrow-down-up');
+      }
+    });
+  }
+
+  container?.addEventListener('scroll', () => {
+    if (container.scrollTop + container.clientHeight >= container.scrollHeight - 10) {
+      loadMore();
+    }
+  });
+
+  form?.addEventListener('submit', async e => {
+    e.preventDefault();
+    if (!form.reportValidity()) return;
+    const data = new FormData(form);
+    let amount = parseFloat(data.get('amount'));
+    amount = form.dataset.type === 'expense' ? -Math.abs(amount) : Math.abs(amount);
+    const payload = {
+      date: data.get('date'),
+      description: data.get('description'),
+      amount,
+      notes: '',
+      account_id: parseInt(data.get('account_id'), 10)
+    };
+    const today = new Date().toISOString().split('T')[0];
+    if (payload.date > today) {
+      alertBox?.classList.remove('d-none', 'alert-success', 'alert-danger');
+      alertBox?.classList.add('alert-danger');
+      if (alertBox) alertBox.textContent = 'La fecha no puede ser futura';
+      return;
+    }
+
+    showOverlay();
+    const result = await createTransaction(payload);
+    hideOverlay();
+    alertBox?.classList.remove('d-none', 'alert-success', 'alert-danger');
+    if (result.ok) {
+      alertBox?.classList.add('alert-success');
+      if (alertBox) alertBox.textContent = 'Movimiento guardado';
+      transactions = [];
+      offset = 0;
+      await loadMore();
+      setTimeout(() => {
+        txModal?.hide();
+        alertBox?.classList.add('d-none');
+      }, 1000);
+    } else {
+      alertBox?.classList.add('alert-danger');
+      if (alertBox) alertBox.textContent = result.error || 'Error al guardar';
+    }
+  });
+
+  if (tbody) {
+    (async function init() {
+      accounts = await fetchAccounts(true);
+      accountMap = Object.fromEntries(accounts.map(a => [a.id, a]));
+      frequents = await fetchFrequents();
+      frequentMap = Object.fromEntries(frequents.map(f => [f.id, f]));
+      await loadMore();
+      updateSortIcons();
+    })();
   }
 });
-
-form.addEventListener('submit', async e => {
-  e.preventDefault();
-  if (!form.reportValidity()) return;
-  const data = new FormData(form);
-  let amount = parseFloat(data.get('amount'));
-  amount = form.dataset.type === 'expense' ? -Math.abs(amount) : Math.abs(amount);
-  const payload = {
-    date: data.get('date'),
-    description: data.get('description'),
-    amount,
-    notes: '',
-    account_id: parseInt(data.get('account_id'), 10)
-  };
-  const today = new Date().toISOString().split('T')[0];
-  if (payload.date > today) {
-    alertBox.classList.remove('d-none', 'alert-success', 'alert-danger');
-    alertBox.classList.add('alert-danger');
-    alertBox.textContent = 'La fecha no puede ser futura';
-    return;
-  }
-
-  showOverlay();
-  const result = await createTransaction(payload);
-  hideOverlay();
-  alertBox.classList.remove('d-none', 'alert-success', 'alert-danger');
-  if (result.ok) {
-    alertBox.classList.add('alert-success');
-    alertBox.textContent = 'Movimiento guardado';
-    transactions = [];
-    offset = 0;
-    await loadMore();
-    setTimeout(() => {
-      txModal.hide();
-      alertBox.classList.add('d-none');
-    }, 1000);
-  } else {
-    alertBox.classList.add('alert-danger');
-    alertBox.textContent = result.error || 'Error al guardar';
-  }
-});
-
-(async function init() {
-  accounts = await fetchAccounts(true);
-  accountMap = Object.fromEntries(accounts.map(a => [a.id, a]));
-  frequents = await fetchFrequents();
-  frequentMap = Object.fromEntries(frequents.map(f => [f.id, f]));
-  await loadMore();
-  updateSortIcons();
-})();


### PR DESCRIPTION
## Summary
- Safely initialize Bootstrap modals only when elements exist
- Guard transaction page event handlers and DOM queries so absent elements don't cause errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0c72075d0833287a12cb3bce740c3