### PR TITLE
feat: add tax details to invoices

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -65,7 +65,12 @@ class Invoice(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     date: Mapped[date] = mapped_column(Date, nullable=False)
     description: Mapped[str] = mapped_column(Text, default="")
+    number: Mapped[str] = mapped_column(String(50), nullable=False)
     amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
+    iva_percent: Mapped[Decimal] = mapped_column(Numeric(5, 2), default=21)
+    iva_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    iibb_percent: Mapped[Decimal] = mapped_column(Numeric(5, 2), default=3)
+    iibb_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
     type: Mapped[InvoiceType] = mapped_column(SqlEnum(InvoiceType), nullable=False)
     account_id: Mapped[int] = mapped_column(ForeignKey("accounts.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -44,8 +44,11 @@ class TransactionWithBalance(TransactionOut):
 class InvoiceCreate(BaseModel):
     account_id: int
     date: date
+    number: str
     description: str = ""
     amount: Decimal
+    iva_percent: Decimal = Decimal("21")
+    iibb_percent: Decimal = Decimal("3")
     type: InvoiceType
 
 
@@ -55,6 +58,11 @@ class InvoiceOut(BaseModel):
     date: date
     description: str
     amount: Decimal
+    number: str
+    iva_percent: Decimal
+    iva_amount: Decimal
+    iibb_percent: Decimal
+    iibb_amount: Decimal
     type: InvoiceType
 
     class Config:

--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -43,7 +43,11 @@ export async function createInvoice(payload) {
   let error = 'Error al guardar';
   try {
     const data = await res.json();
-    error = data.detail || error;
+    if (Array.isArray(data.detail)) {
+      error = data.detail.map(d => d.msg).join(', ');
+    } else {
+      error = data.detail || error;
+    }
   } catch (_) {}
   return { ok: false, error };
 }

--- a/app/static/js/billing.js
+++ b/app/static/js/billing.js
@@ -1,5 +1,5 @@
 import { fetchAccounts, fetchInvoices, createInvoice } from './api.js';
-import { renderTransaction, populateAccounts, showOverlay, hideOverlay } from './ui.js';
+import { renderTransaction, showOverlay, hideOverlay } from './ui.js';
 
 const tbody = document.querySelector('#inv-table tbody');
 const container = document.getElementById('table-container');
@@ -9,12 +9,19 @@ const form = document.getElementById('inv-form');
 const alertBox = document.getElementById('inv-alert');
 const searchBox = document.getElementById('search-box');
 const headers = document.querySelectorAll('#inv-table thead th.sortable');
+const amountInput = form.amount;
+const ivaPercentInput = form.iva_percent;
+const ivaAmountInput = form.iva_amount;
+const iibbPercentInput = form.iibb_percent;
+const iibbAmountInput = form.iibb_amount;
+const billingAccountLabel = document.getElementById('billing-account');
 
 let offset = 0;
 const limit = 50;
 let loading = false;
 let accounts = [];
 let accountMap = {};
+let billingAccount = null;
 let invoices = [];
 let sortColumn = 0;
 let sortAsc = false;
@@ -23,7 +30,11 @@ function renderInvoices() {
   const q = searchBox.value.trim().toLowerCase();
   const filtered = invoices.filter(inv => {
     const accName = accountMap[inv.account_id]?.name.toLowerCase() || '';
-    return inv.description.toLowerCase().includes(q) || accName.includes(q);
+    return (
+      inv.description.toLowerCase().includes(q) ||
+      (inv.number || '').toLowerCase().includes(q) ||
+      accName.includes(q)
+    );
   });
   filtered.sort((a, b) => {
     switch (sortColumn) {
@@ -49,6 +60,20 @@ function renderInvoices() {
   filtered.forEach(inv => renderTransaction(tbody, inv, accountMap));
 }
 
+function recalcTaxes() {
+  const amount = parseFloat(amountInput.value) || 0;
+  const ivaPercent = parseFloat(ivaPercentInput.value) || 0;
+  const ivaAmount = amount * ivaPercent / 100;
+  ivaAmountInput.value = ivaAmount.toFixed(2);
+  const iibbPercent = parseFloat(iibbPercentInput.value) || 0;
+  const iibbAmount = (amount + ivaAmount) * iibbPercent / 100;
+  iibbAmountInput.value = iibbAmount.toFixed(2);
+}
+
+amountInput.addEventListener('input', recalcTaxes);
+ivaPercentInput.addEventListener('input', recalcTaxes);
+iibbPercentInput.addEventListener('input', recalcTaxes);
+
 async function loadMore() {
   if (loading) return;
   loading = true;
@@ -60,16 +85,22 @@ async function loadMore() {
 }
 
 function openModal(type) {
+  if (!billingAccount) {
+    alert('Se requiere una cuenta de facturación');
+    return;
+  }
   form.reset();
-  document.getElementById('form-title').textContent = type === 'sale' ? 'Nueva Factura de Venta' : 'Nueva Factura de Compra';
-  populateAccounts(form.account_id, accounts.filter(a => a.is_active));
-  const billing = accounts.find(a => a.is_billing);
-  if (billing) form.account_id.value = billing.id;
+  document.getElementById('form-title').textContent =
+    type === 'sale' ? 'Nueva Factura de Venta' : 'Nueva Factura de Compra';
+  form.account_id.value = billingAccount.id;
+  billingAccountLabel.textContent = billingAccount.name;
+  billingAccountLabel.style.color = billingAccount.color;
   form.dataset.type = type;
   alertBox.classList.add('d-none');
   const today = new Date().toISOString().split('T')[0];
   form.date.max = today;
   form.date.value = today;
+  recalcTaxes();
   invModal.show();
 }
 
@@ -117,10 +148,13 @@ form.addEventListener('submit', async e => {
   amount = form.dataset.type === 'purchase' ? -Math.abs(amount) : Math.abs(amount);
   const payload = {
     date: data.get('date'),
+    number: data.get('number'),
     description: data.get('description'),
     amount,
-    account_id: parseInt(data.get('account_id'), 10),
-    type: form.dataset.type
+    account_id: billingAccount.id,
+    type: form.dataset.type,
+    iva_percent: parseFloat(data.get('iva_percent')) || 0,
+    iibb_percent: parseFloat(data.get('iibb_percent')) || 0
   };
   const today = new Date().toISOString().split('T')[0];
   if (payload.date > today) {
@@ -153,6 +187,7 @@ form.addEventListener('submit', async e => {
 (async function init() {
   accounts = await fetchAccounts(true);
   accountMap = Object.fromEntries(accounts.map(a => [a.id, a]));
+  billingAccount = accounts.find(a => a.is_billing);
   await loadMore();
   updateSortIcons();
 })();

--- a/app/static/js/ui.js
+++ b/app/static/js/ui.js
@@ -21,9 +21,10 @@ export function renderTransaction(tbody, tx, accountMap) {
   const descStyle = isIncome ? '' : ' style="padding-left:2em"';
   const amountClass = isIncome ? 'text-start' : 'text-end';
   const amountColor = isIncome ? 'rgb(40,150,20)' : 'rgb(170,10,10)';
+  const concept = tx.number ? `${tx.number} - ${tx.description}` : tx.description;
   tr.innerHTML =
     `<td class="text-center">${formattedDate}</td>` +
-    `<td class="${descClass}"${descStyle}>${tx.description}</td>` +
+    `<td class="${descClass}"${descStyle}>${concept}</td>` +
     `<td class="${amountClass}" style="color:${amountColor}">${symbol} ${amount}</td>` +
     `<td class="text-center" style="color:${accColor}">${accName}</td>`;
   tr.addEventListener('click', () => {

--- a/app/templates/billing.html
+++ b/app/templates/billing.html
@@ -41,19 +41,48 @@
               </label>
             </div>
             <div class="mb-3">
+              <label class="form-label">Número
+                <input type="text" name="number" class="form-control" required>
+              </label>
+            </div>
+            <div class="mb-3">
               <label class="form-label">Concepto
                 <input type="text" name="description" class="form-control" required>
               </label>
             </div>
             <div class="mb-3">
-              <label class="form-label">Monto
+              <label class="form-label">Total sin impuesto
                 <input type="number" step="0.01" name="amount" class="form-control" required>
               </label>
             </div>
+            <div class="row">
+              <div class="col-6 mb-3">
+                <label class="form-label">IVA %
+                  <input type="number" step="0.01" name="iva_percent" class="form-control" value="21">
+                </label>
+              </div>
+              <div class="col-6 mb-3">
+                <label class="form-label">IVA $
+                  <input type="number" step="0.01" name="iva_amount" class="form-control" readonly>
+                </label>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-6 mb-3">
+                <label class="form-label">IIBB %
+                  <input type="number" step="0.01" name="iibb_percent" class="form-control" value="3">
+                </label>
+              </div>
+              <div class="col-6 mb-3">
+                <label class="form-label">IIBB $
+                  <input type="number" step="0.01" name="iibb_amount" class="form-control" readonly>
+                </label>
+              </div>
+            </div>
             <div class="mb-3">
-              <label class="form-label">Cuenta
-                <select name="account_id" class="form-select" required></select>
-              </label>
+              <span class="form-label d-block">Cuenta de facturación:</span>
+              <span id="billing-account" class="fw-bold"></span>
+              <input type="hidden" name="account_id">
             </div>
             <div id="inv-alert" class="alert d-none" role="alert"></div>
           </div>


### PR DESCRIPTION
## Summary
- add invoice number and tax fields with auto-calculation
- expose new tax data in API and UI
- associate invoices to billing account and improve validation errors

## Testing
- `python -m py_compile app/models.py app/routes/invoices.py app/schemas.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1f7c55f448332bb10fa18015f4fb8