### PR TITLE
Fix invoice table totals and add detail view

### DIFF
--- a/app/static/js/billing.js
+++ b/app/static/js/billing.js
@@ -55,8 +55,10 @@ function renderInvoices() {
           ? a.description.localeCompare(b.description)
           : b.description.localeCompare(a.description);
       case 4:
-        const totalA = Number(a.amount) + Number(a.iva_amount);
-        const totalB = Number(b.amount) + Number(b.iva_amount);
+        const totalA =
+          Number(a.amount) + Number(a.iva_amount) + Number(a.iibb_amount);
+        const totalB =
+          Number(b.amount) + Number(b.iva_amount) + Number(b.iibb_amount);
         return sortAsc ? totalA - totalB : totalB - totalA;
       default:
         return 0;

--- a/app/static/js/ui.js
+++ b/app/static/js/ui.js
@@ -48,7 +48,8 @@ export function renderInvoice(tbody, inv, accountMap) {
     })
     .replace('.', '');
   const typeText = inv.type === 'sale' ? 'Venta' : 'Compra';
-  const total = Number(inv.amount) + Number(inv.iva_amount);
+  const total =
+    Number(inv.amount) + Number(inv.iva_amount) + Number(inv.iibb_amount);
   const amountColor = total >= 0 ? 'rgb(40,150,20)' : 'rgb(170,10,10)';
   const amount = Math.abs(total).toFixed(2);
   tr.innerHTML =
@@ -57,9 +58,9 @@ export function renderInvoice(tbody, inv, accountMap) {
     `<td class="text-center">${typeText}</td>` +
     `<td>${inv.description}</td>` +
     `<td class="text-end" style="color:${amountColor}">${symbol} ${amount}</td>`;
+  tr.style.cursor = 'pointer';
   tr.addEventListener('click', () => {
-    tbody.querySelectorAll('tr').forEach(r => r.classList.remove('selected'));
-    tr.classList.add('selected');
+    window.location.href = `/invoice/${inv.id}`;
   });
   tbody.appendChild(tr);
 }

--- a/app/templates/billing.html
+++ b/app/templates/billing.html
@@ -69,7 +69,7 @@
                 </label>
               </div>
             </div>
-            <div class="row" id="iibb-row">
+            <div class="row d-none" id="iibb-row">
               <div class="col-6 mb-3">
                 <label class="form-label">IIBB %
                   <input type="number" step="0.01" name="iibb_percent" class="form-control" value="3">

--- a/app/templates/invoice_detail.html
+++ b/app/templates/invoice_detail.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container my-4">
+  <h2>Factura {{ invoice.number }}</h2>
+  <table class="table table-bordered w-auto">
+    <tbody>
+      <tr><th>Fecha</th><td>{{ invoice.date }}</td></tr>
+      <tr><th>Tipo</th><td>{{ 'Venta' if invoice.type == 'sale' else 'Compra' }}</td></tr>
+      <tr><th>Cuenta</th><td style="color:{{ account.color if account else '' }}">{{ account.name if account else '' }}</td></tr>
+      <tr><th>Concepto</th><td>{{ invoice.description }}</td></tr>
+      <tr><th>Monto sin impuesto</th><td>{{ symbol }} {{ '%.2f'|format(invoice.amount) }}</td></tr>
+      <tr><th>IVA %</th><td>{{ invoice.iva_percent }}%</td></tr>
+      <tr><th>IVA $</th><td>{{ symbol }} {{ '%.2f'|format(invoice.iva_amount) }}</td></tr>
+      {% if invoice.iibb_amount %}
+      <tr><th>IIBB %</th><td>{{ invoice.iibb_percent }}%</td></tr>
+      <tr><th>IIBB $</th><td>{{ symbol }} {{ '%.2f'|format(invoice.iibb_amount) }}</td></tr>
+      {% endif %}
+      <tr><th>Total</th><td>{{ symbol }} {{ '%.2f'|format(total) }}</td></tr>
+    </tbody>
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Include gross income tax in invoice totals and enable row navigation to details
- Hide IIBB fields in purchase invoice modal
- Add invoice detail page to display full invoice information

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2075e015c833286553bb006266b8a