### PR TITLE
Rename IIBB labels to IIBB/SIRCREB

### DIFF
--- a/app/static/js/accounts.js
+++ b/app/static/js/accounts.js
@@ -67,7 +67,7 @@ async function toggleDetails(row, acc) {
     html += `<p><strong>IVA Compras:</strong> <span class="text-success">${symbol} ${formatCurrency(summary.iva_purchases)}</span></p>`;
     html += `<p><strong>IVA Ventas:</strong> <span class="text-danger">${symbol} ${formatCurrency(summary.iva_sales)}</span></p>`;
     html += `<p><strong>Balance IVA:</strong> <span class="text-dark fst-italic">${symbol} ${formatCurrency(ivaBalance)}</span></p>`;
-    html += `<p><strong>IIBB:</strong> <span class="text-danger">${symbol} ${formatCurrency(summary.iibb)}</span></p>`;
+    html += `<p><strong>IIBB/SIRCREB:</strong> <span class="text-danger">${symbol} ${formatCurrency(summary.iibb)}</span></p>`;
     html += '</div>';
   }
   html += '</div>';

--- a/app/templates/billing.html
+++ b/app/templates/billing.html
@@ -73,12 +73,12 @@
             </div>
             <div id="iibb-row" class="mb-3 d-none">
               <div class="tax-line">
-                <span class="form-label tax-label mb-0">IIBB</span>
-                <input type="number" step="0.01" name="iibb_percent" class="form-control tax-percent text-end" value="3" aria-label="IIBB %">
+                <span class="form-label tax-label mb-0">IIBB/SIRCREB</span>
+                <input type="number" step="0.01" name="iibb_percent" class="form-control tax-percent text-end" value="3" aria-label="IIBB/SIRCREB %">
                 <span class="tax-symbol">%</span>
                 <span class="tax-separator">-</span>
                 <span class="tax-symbol">$</span>
-                <input type="text" name="iibb_amount" class="form-control tax-amount text-end" readonly aria-label="IIBB $">
+                <input type="text" name="iibb_amount" class="form-control tax-amount text-end" readonly aria-label="IIBB/SIRCREB $">
               </div>
             </div>
             <div class="mb-3">

--- a/app/templates/invoice_detail.html
+++ b/app/templates/invoice_detail.html
@@ -20,7 +20,7 @@
       <tr><th>Monto sin impuesto</th><td class="amount">{{ symbol }} {{ invoice.amount|money }}</td></tr>
       <tr><th>IVA {{ invoice.iva_percent }}%</th><td class="amount">{{ symbol }} {{ invoice.iva_amount|money }}</td></tr>
       {% if invoice.iibb_amount %}
-      <tr><th>IIBB {{ invoice.iibb_percent }}%</th><td class="amount">{{ symbol }} {{ invoice.iibb_amount|money }}</td></tr>
+      <tr><th>IIBB/SIRCREB {{ invoice.iibb_percent }}%</th><td class="amount">{{ symbol }} {{ invoice.iibb_amount|money }}</td></tr>
       {% endif %}
       <tr class="total"><th>Total</th><td class="amount">{{ symbol }} {{ total|money }}</td></tr>
     </tbody>
@@ -84,12 +84,12 @@
           </div>
           <div id="iibb-row" class="row d-none">
             <div class="col-6 mb-3">
-              <label class="form-label">IIBB %
+              <label class="form-label">IIBB/SIRCREB %
                 <input type="number" step="0.01" name="iibb_percent" class="form-control" value="3">
               </label>
             </div>
             <div class="col-6 mb-3">
-              <label class="form-label">IIBB $
+              <label class="form-label">IIBB/SIRCREB $
                 <input type="text" name="iibb_amount" class="form-control" readonly>
               </label>
             </div>

--- a/app/templates/invoice_edit.html
+++ b/app/templates/invoice_edit.html
@@ -37,12 +37,12 @@
     </div>
     <div id="iibb-row" class="row{% if invoice.type == 'purchase' %} d-none{% endif %}">
       <div class="col-6 mb-3">
-        <label class="form-label">IIBB %
+        <label class="form-label">IIBB/SIRCREB %
           <input type="number" step="0.01" name="iibb_percent" class="form-control" value="{{ invoice.iibb_percent }}">
         </label>
       </div>
       <div class="col-6 mb-3">
-        <label class="form-label">IIBB $
+        <label class="form-label">IIBB/SIRCREB $
           <input type="text" name="iibb_amount" class="form-control" value="{{ invoice.iibb_amount }}" readonly>
         </label>
       </div>


### PR DESCRIPTION
## Summary
- rename displayed IIBB labels to IIBB/SIRCREB across billing and invoice views
- update account summary modal to show IIBB/SIRCREB label

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9780d4ca48332aa046d7da1845ac4