### PR TITLE
Allow manual tax overrides in billing modal

### DIFF
--- a/app/routes/invoices.py
+++ b/app/routes/invoices.py
@@ -23,18 +23,28 @@ def create_invoice(payload: InvoiceCreate, db: Session = Depends(get_db)):
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No se permiten fechas futuras",
         )
-    iva_amount = (payload.amount * payload.iva_percent / Decimal("100")).quantize(
-        Decimal("0.01")
-    )
-    if payload.type == InvoiceType.SALE:
-        iibb_base = payload.amount + iva_amount
-        iibb_percent = payload.iibb_percent
-        iibb_amount = (iibb_base * iibb_percent / Decimal("100")).quantize(
+    if payload.iva_amount is not None:
+        iva_amount = abs(payload.iva_amount).quantize(Decimal("0.01"))
+    else:
+        iva_amount = (payload.amount * payload.iva_percent / Decimal("100")).quantize(
             Decimal("0.01")
         )
+    if payload.type == InvoiceType.SALE:
+        iibb_percent = payload.iibb_percent
+        if payload.iibb_amount is not None:
+            iibb_amount = abs(payload.iibb_amount).quantize(Decimal("0.01"))
+        else:
+            iibb_base = payload.amount + iva_amount
+            iibb_amount = (iibb_base * iibb_percent / Decimal("100")).quantize(
+                Decimal("0.01")
+            )
     else:
         iibb_percent = Decimal("0")
-        iibb_amount = Decimal("0")
+        iibb_amount = (
+            abs(payload.iibb_amount).quantize(Decimal("0.01"))
+            if payload.iibb_amount is not None
+            else Decimal("0")
+        )
     inv = Invoice(
         account_id=payload.account_id,
         date=payload.date,
@@ -72,18 +82,28 @@ def update_invoice(invoice_id: int, payload: InvoiceCreate, db: Session = Depend
         raise HTTPException(status_code=404, detail="Factura no encontrada")
     if payload.date > date.today():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No se permiten fechas futuras")
-    iva_amount = (payload.amount * payload.iva_percent / Decimal("100")).quantize(
-        Decimal("0.01")
-    )
-    if payload.type == InvoiceType.SALE:
-        iibb_base = payload.amount + iva_amount
-        iibb_percent = payload.iibb_percent
-        iibb_amount = (iibb_base * iibb_percent / Decimal("100")).quantize(
+    if payload.iva_amount is not None:
+        iva_amount = abs(payload.iva_amount).quantize(Decimal("0.01"))
+    else:
+        iva_amount = (payload.amount * payload.iva_percent / Decimal("100")).quantize(
             Decimal("0.01")
         )
+    if payload.type == InvoiceType.SALE:
+        iibb_percent = payload.iibb_percent
+        if payload.iibb_amount is not None:
+            iibb_amount = abs(payload.iibb_amount).quantize(Decimal("0.01"))
+        else:
+            iibb_base = payload.amount + iva_amount
+            iibb_amount = (iibb_base * iibb_percent / Decimal("100")).quantize(
+                Decimal("0.01")
+            )
     else:
         iibb_percent = Decimal("0")
-        iibb_amount = Decimal("0")
+        iibb_amount = (
+            abs(payload.iibb_amount).quantize(Decimal("0.01"))
+            if payload.iibb_amount is not None
+            else Decimal("0")
+        )
     for field in [
         "account_id",
         "date",

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -49,6 +49,8 @@ class InvoiceCreate(BaseModel):
     amount: Decimal
     iva_percent: Decimal = Decimal("21")
     iibb_percent: Decimal = Decimal("3")
+    iva_amount: Decimal | None = None
+    iibb_amount: Decimal | None = None
     type: InvoiceType
 
 

--- a/app/templates/billing.html
+++ b/app/templates/billing.html
@@ -64,21 +64,21 @@
             <div class="mb-3">
               <div class="tax-line">
                 <span class="form-label tax-label mb-0">IVA</span>
-                <input type="number" step="0.01" name="iva_percent" class="form-control tax-percent text-end" value="21" aria-label="IVA %">
+                <input type="text" inputmode="decimal" name="iva_percent" class="form-control tax-percent text-end" value="21" aria-label="IVA %">
                 <span class="tax-symbol">%</span>
                 <span class="tax-separator">-</span>
                 <span class="tax-symbol">$</span>
-                <input type="text" name="iva_amount" class="form-control tax-amount text-end" readonly aria-label="IVA $">
+                <input type="text" inputmode="decimal" name="iva_amount" class="form-control tax-amount text-end" aria-label="IVA $">
               </div>
             </div>
             <div id="iibb-row" class="mb-3 d-none">
               <div class="tax-line">
                 <span class="form-label tax-label mb-0">IIBB/SIRCREB</span>
-                <input type="number" step="0.01" name="iibb_percent" class="form-control tax-percent text-end" value="3" aria-label="IIBB/SIRCREB %">
+                <input type="text" inputmode="decimal" name="iibb_percent" class="form-control tax-percent text-end" value="3" aria-label="IIBB/SIRCREB %">
                 <span class="tax-symbol">%</span>
                 <span class="tax-separator">-</span>
                 <span class="tax-symbol">$</span>
-                <input type="text" name="iibb_amount" class="form-control tax-amount text-end" readonly aria-label="IIBB/SIRCREB $">
+                <input type="text" inputmode="decimal" name="iibb_amount" class="form-control tax-amount text-end" aria-label="IIBB/SIRCREB $">
               </div>
             </div>
             <div class="mb-3">


### PR DESCRIPTION
## Summary
- make the IVA and IIBB fields in the billing modal editable for percentage and amount
- update the billing modal script to flag manual values, keep amounts in sync and send overrides to the backend
- allow invoice endpoints to accept optional tax amounts so manual overrides persist

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c99e31ca008332b7db0187f42c8b15