### PR TITLE
Refine tax layout to prefix symbols

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -5,13 +5,22 @@ body {
 .tax-line {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  flex-wrap: nowrap;
-
+  flex-wrap: wrap;
 }
 
 .tax-label {
   min-width: 3.5rem;
+  margin-right: 0.75rem;
+}
+
+.tax-field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tax-field-amount {
+  margin-left: 5ch;
 }
 
 .tax-line .form-control {
@@ -28,9 +37,13 @@ body {
   min-width: 0;
 }
 
-.tax-symbol,
-.tax-separator {
+.tax-symbol {
   font-weight: 600;
+}
+
+.tax-symbol-percent,
+.tax-symbol-currency {
+  display: inline-block;
 }
 
 #table-container {

--- a/app/static/js/accounts.js
+++ b/app/static/js/accounts.js
@@ -67,7 +67,7 @@ async function toggleDetails(row, acc) {
     html += `<p><strong>IVA Compras:</strong> <span class="text-success">${symbol} ${formatCurrency(summary.iva_purchases)}</span></p>`;
     html += `<p><strong>IVA Ventas:</strong> <span class="text-danger">${symbol} ${formatCurrency(summary.iva_sales)}</span></p>`;
     html += `<p><strong>Balance IVA:</strong> <span class="text-dark fst-italic">${symbol} ${formatCurrency(ivaBalance)}</span></p>`;
-    html += `<p><strong>IIBB/SIRCREB:</strong> <span class="text-danger">${symbol} ${formatCurrency(summary.iibb)}</span></p>`;
+    html += `<p><strong>SIRCREB:</strong> <span class="text-danger">${symbol} ${formatCurrency(summary.iibb)}</span></p>`;
     html += '</div>';
   }
   html += '</div>';

--- a/app/templates/billing.html
+++ b/app/templates/billing.html
@@ -64,21 +64,27 @@
             <div class="mb-3">
               <div class="tax-line">
                 <span class="form-label tax-label mb-0">IVA</span>
-                <input type="number" step="0.01" name="iva_percent" class="form-control tax-percent text-end" value="21" aria-label="IVA %">
-                <span class="tax-symbol">%</span>
-                <span class="tax-separator">-</span>
-                <span class="tax-symbol">$</span>
-                <input type="text" name="iva_amount" class="form-control tax-amount text-end" readonly aria-label="IVA $">
+                <div class="tax-field">
+                  <span class="tax-symbol tax-symbol-percent">%</span>
+                  <input type="number" step="0.01" name="iva_percent" class="form-control tax-percent text-end" value="21" aria-label="Porcentaje de IVA">
+                </div>
+                <div class="tax-field tax-field-amount">
+                  <span class="tax-symbol tax-symbol-currency">$</span>
+                  <input type="text" name="iva_amount" class="form-control tax-amount text-end" readonly aria-label="Monto de IVA">
+                </div>
               </div>
             </div>
             <div id="iibb-row" class="mb-3 d-none">
               <div class="tax-line">
-                <span class="form-label tax-label mb-0">IIBB/SIRCREB</span>
-                <input type="number" step="0.01" name="iibb_percent" class="form-control tax-percent text-end" value="3" aria-label="IIBB/SIRCREB %">
-                <span class="tax-symbol">%</span>
-                <span class="tax-separator">-</span>
-                <span class="tax-symbol">$</span>
-                <input type="text" name="iibb_amount" class="form-control tax-amount text-end" readonly aria-label="IIBB/SIRCREB $">
+                <span class="form-label tax-label mb-0">SIRCREB</span>
+                <div class="tax-field">
+                  <span class="tax-symbol tax-symbol-percent">%</span>
+                  <input type="number" step="0.01" name="iibb_percent" class="form-control tax-percent text-end" value="3" aria-label="Porcentaje de SIRCREB">
+                </div>
+                <div class="tax-field tax-field-amount">
+                  <span class="tax-symbol tax-symbol-currency">$</span>
+                  <input type="text" name="iibb_amount" class="form-control tax-amount text-end" readonly aria-label="Monto de SIRCREB">
+                </div>
               </div>
             </div>
             <div class="mb-3">

--- a/app/templates/invoice_detail.html
+++ b/app/templates/invoice_detail.html
@@ -18,9 +18,9 @@
       <tr><th>Cuenta</th><td style="color:{{ account.color if account else '' }}">{{ account.name if account else '' }}</td></tr>
       <tr><th>Concepto</th><td class="description">{{ invoice.description }}</td></tr>
       <tr><th>Monto sin impuesto</th><td class="amount">{{ symbol }} {{ invoice.amount|money }}</td></tr>
-      <tr><th>IVA {{ invoice.iva_percent }}%</th><td class="amount">{{ symbol }} {{ invoice.iva_amount|money }}</td></tr>
+      <tr><th>IVA % {{ invoice.iva_percent }}</th><td class="amount">{{ symbol }} {{ invoice.iva_amount|money }}</td></tr>
       {% if invoice.iibb_amount %}
-      <tr><th>IIBB/SIRCREB {{ invoice.iibb_percent }}%</th><td class="amount">{{ symbol }} {{ invoice.iibb_amount|money }}</td></tr>
+      <tr><th>SIRCREB % {{ invoice.iibb_percent }}</th><td class="amount">{{ symbol }} {{ invoice.iibb_amount|money }}</td></tr>
       {% endif %}
       <tr class="total"><th>Total</th><td class="amount">{{ symbol }} {{ total|money }}</td></tr>
     </tbody>
@@ -70,28 +70,30 @@
               <input type="number" step="0.01" name="amount" class="form-control" required>
             </label>
           </div>
-          <div class="row">
-            <div class="col-6 mb-3">
-              <label class="form-label">IVA %
-                <input type="number" step="0.01" name="iva_percent" class="form-control" value="21">
-              </label>
-            </div>
-            <div class="col-6 mb-3">
-              <label class="form-label">IVA $
-                <input type="text" name="iva_amount" class="form-control" readonly>
-              </label>
+          <div class="mb-3">
+            <div class="tax-line">
+              <span class="form-label tax-label mb-0">IVA</span>
+              <div class="tax-field">
+                <span class="tax-symbol tax-symbol-percent">%</span>
+                <input type="number" step="0.01" name="iva_percent" class="form-control tax-percent text-end" value="21">
+              </div>
+              <div class="tax-field tax-field-amount">
+                <span class="tax-symbol tax-symbol-currency">$</span>
+                <input type="text" name="iva_amount" class="form-control tax-amount text-end" readonly>
+              </div>
             </div>
           </div>
-          <div id="iibb-row" class="row d-none">
-            <div class="col-6 mb-3">
-              <label class="form-label">IIBB/SIRCREB %
-                <input type="number" step="0.01" name="iibb_percent" class="form-control" value="3">
-              </label>
-            </div>
-            <div class="col-6 mb-3">
-              <label class="form-label">IIBB/SIRCREB $
-                <input type="text" name="iibb_amount" class="form-control" readonly>
-              </label>
+          <div id="iibb-row" class="mb-3 d-none">
+            <div class="tax-line">
+              <span class="form-label tax-label mb-0">SIRCREB</span>
+              <div class="tax-field">
+                <span class="tax-symbol tax-symbol-percent">%</span>
+                <input type="number" step="0.01" name="iibb_percent" class="form-control tax-percent text-end" value="3">
+              </div>
+              <div class="tax-field tax-field-amount">
+                <span class="tax-symbol tax-symbol-currency">$</span>
+                <input type="text" name="iibb_amount" class="form-control tax-amount text-end" readonly>
+              </div>
             </div>
           </div>
           <div class="mb-3">

--- a/app/templates/invoice_edit.html
+++ b/app/templates/invoice_edit.html
@@ -23,28 +23,30 @@
         <input type="number" step="0.01" name="amount" class="form-control" value="{{ invoice.amount }}" required>
       </label>
     </div>
-    <div class="row">
-      <div class="col-6 mb-3">
-        <label class="form-label">IVA %
-          <input type="number" step="0.01" name="iva_percent" class="form-control" value="{{ invoice.iva_percent }}">
-        </label>
-      </div>
-      <div class="col-6 mb-3">
-        <label class="form-label">IVA $
-          <input type="text" name="iva_amount" class="form-control" value="{{ invoice.iva_amount }}" readonly>
-        </label>
+    <div class="mb-3">
+      <div class="tax-line">
+        <span class="form-label tax-label mb-0">IVA</span>
+        <div class="tax-field">
+          <span class="tax-symbol tax-symbol-percent">%</span>
+          <input type="number" step="0.01" name="iva_percent" class="form-control tax-percent text-end" value="{{ invoice.iva_percent }}">
+        </div>
+        <div class="tax-field tax-field-amount">
+          <span class="tax-symbol tax-symbol-currency">$</span>
+          <input type="text" name="iva_amount" class="form-control tax-amount text-end" value="{{ invoice.iva_amount }}" readonly>
+        </div>
       </div>
     </div>
-    <div id="iibb-row" class="row{% if invoice.type == 'purchase' %} d-none{% endif %}">
-      <div class="col-6 mb-3">
-        <label class="form-label">IIBB/SIRCREB %
-          <input type="number" step="0.01" name="iibb_percent" class="form-control" value="{{ invoice.iibb_percent }}">
-        </label>
-      </div>
-      <div class="col-6 mb-3">
-        <label class="form-label">IIBB/SIRCREB $
-          <input type="text" name="iibb_amount" class="form-control" value="{{ invoice.iibb_amount }}" readonly>
-        </label>
+    <div id="iibb-row" class="mb-3{% if invoice.type == 'purchase' %} d-none{% endif %}">
+      <div class="tax-line">
+        <span class="form-label tax-label mb-0">SIRCREB</span>
+        <div class="tax-field">
+          <span class="tax-symbol tax-symbol-percent">%</span>
+          <input type="number" step="0.01" name="iibb_percent" class="form-control tax-percent text-end" value="{{ invoice.iibb_percent }}">
+        </div>
+        <div class="tax-field tax-field-amount">
+          <span class="tax-symbol tax-symbol-currency">$</span>
+          <input type="text" name="iibb_amount" class="form-control tax-amount text-end" value="{{ invoice.iibb_amount }}" readonly>
+        </div>
       </div>
     </div>
     <div class="mb-3">


### PR DESCRIPTION
## Summary
- restructure tax input markup so % and $ appear before their fields with consistent spacing across billing and invoice edit forms
- update shared tax layout styles to support grouped prefixes and maintain the requested five-character gap before the currency field
- adjust invoice detail view to show percent prefixes for tax values while keeping the SIRCREB label consistent throughout

## Testing
- not run (frontend-only change)

------
https://chatgpt.com/codex/tasks/task_e_68c9c85dd45883329522ce5c9109e905