### PR TITLE
Restore editable invoice modal amounts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -180,14 +180,16 @@ async def edit_invoice_page(
         raise HTTPException(status_code=404, detail="Factura no encontrada")
     acc = db.get(Account, inv.account_id)
     symbol = CURRENCY_SYMBOLS.get(acc.currency) if acc else ""
+    invoice_data = jsonable_encoder(inv)
+    account_data = jsonable_encoder(acc) if acc else None
     return templates.TemplateResponse(
         "invoice_edit.html",
         {
             "request": request,
             "title": "Editar factura",
             "header_title": "Editar factura",
-            "invoice": inv,
-            "account": acc,
+            "invoice": invoice_data,
+            "account": account_data,
             "symbol": symbol,
             "user": user,
         },

--- a/app/templates/billing.html
+++ b/app/templates/billing.html
@@ -70,7 +70,7 @@
                 </div>
                 <div class="tax-field tax-field-amount">
                   <span class="tax-symbol tax-symbol-currency">$</span>
-                  <input type="text" name="iva_amount" class="form-control tax-amount text-end" readonly aria-label="Monto de IVA">
+                  <input type="text" name="iva_amount" class="form-control tax-amount text-end" aria-label="Monto de IVA">
                 </div>
               </div>
             </div>
@@ -83,7 +83,7 @@
                 </div>
                 <div class="tax-field tax-field-amount">
                   <span class="tax-symbol tax-symbol-currency">$</span>
-                  <input type="text" name="iibb_amount" class="form-control tax-amount text-end" readonly aria-label="Monto de SIRCREB">
+                  <input type="text" name="iibb_amount" class="form-control tax-amount text-end" aria-label="Monto de SIRCREB">
                 </div>
               </div>
             </div>

--- a/app/templates/invoice_detail.html
+++ b/app/templates/invoice_detail.html
@@ -50,36 +50,40 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
         </div>
         <div class="modal-body">
-          <div class="mb-3">
-            <label class="form-label">Fecha
-              <input type="date" name="date" class="form-control" required>
-            </label>
+          <div class="row g-3 mb-3">
+            <div class="col-sm-6">
+              <label class="form-label w-100">Fecha
+                <input type="date" name="date" class="form-control" required>
+              </label>
+            </div>
+            <div class="col-sm-6">
+              <label class="form-label w-100">Número
+                <input type="text" name="number" class="form-control" required>
+              </label>
+            </div>
           </div>
           <div class="mb-3">
-            <label class="form-label">Número
-              <input type="text" name="number" class="form-control" required>
-            </label>
-          </div>
-          <div class="mb-3">
-            <label class="form-label">Concepto
+            <label class="form-label w-100">Concepto
               <input type="text" name="description" class="form-control" required>
             </label>
           </div>
-          <div class="mb-3">
-            <label class="form-label">Total sin impuesto
-              <input type="number" step="0.01" name="amount" class="form-control" required>
-            </label>
+          <div class="row g-3 justify-content-end mb-3">
+            <div class="col-sm-6 ms-auto">
+              <label class="form-label w-100">Total sin impuesto
+                <input type="number" step="0.01" name="amount" class="form-control text-end" required>
+              </label>
+            </div>
           </div>
           <div class="mb-3">
             <div class="tax-line">
               <span class="form-label tax-label mb-0">IVA</span>
               <div class="tax-field">
                 <span class="tax-symbol tax-symbol-percent">%</span>
-                <input type="number" step="0.01" name="iva_percent" class="form-control tax-percent text-end" value="21">
+                <input type="number" step="0.01" name="iva_percent" class="form-control tax-percent text-end" value="21" aria-label="Porcentaje de IVA">
               </div>
               <div class="tax-field tax-field-amount">
                 <span class="tax-symbol tax-symbol-currency">$</span>
-                <input type="text" name="iva_amount" class="form-control tax-amount text-end" readonly>
+                <input type="text" name="iva_amount" class="form-control tax-amount text-end" aria-label="Monto de IVA">
               </div>
             </div>
           </div>
@@ -88,11 +92,11 @@
               <span class="form-label tax-label mb-0">SIRCREB</span>
               <div class="tax-field">
                 <span class="tax-symbol tax-symbol-percent">%</span>
-                <input type="number" step="0.01" name="iibb_percent" class="form-control tax-percent text-end" value="3">
+                <input type="number" step="0.01" name="iibb_percent" class="form-control tax-percent text-end" value="3" aria-label="Porcentaje de SIRCREB">
               </div>
               <div class="tax-field tax-field-amount">
                 <span class="tax-symbol tax-symbol-currency">$</span>
-                <input type="text" name="iibb_amount" class="form-control tax-amount text-end" readonly>
+                <input type="text" name="iibb_amount" class="form-control tax-amount text-end" aria-label="Monto de SIRCREB">
               </div>
             </div>
           </div>

--- a/app/templates/invoice_edit.html
+++ b/app/templates/invoice_edit.html
@@ -3,36 +3,40 @@
 {% block content %}
 <div class="container mt-4" style="max-width:500px;">
   <form id="inv-form" data-type="{{ invoice.type }}" data-invoice-id="{{ invoice.id }}">
-    <div class="mb-3">
-      <label class="form-label">Fecha
-        <input type="date" name="date" class="form-control" value="{{ invoice.date }}" required>
-      </label>
+    <div class="row g-3 mb-3">
+      <div class="col-sm-6">
+        <label class="form-label w-100">Fecha
+          <input type="date" name="date" class="form-control" value="{{ invoice.date }}" required>
+        </label>
+      </div>
+      <div class="col-sm-6">
+        <label class="form-label w-100">Número
+          <input type="text" name="number" class="form-control" value="{{ invoice.number }}" required>
+        </label>
+      </div>
     </div>
     <div class="mb-3">
-      <label class="form-label">Número
-        <input type="text" name="number" class="form-control" value="{{ invoice.number }}" required>
-      </label>
-    </div>
-    <div class="mb-3">
-      <label class="form-label">Concepto
+      <label class="form-label w-100">Concepto
         <input type="text" name="description" class="form-control" value="{{ invoice.description }}" required>
       </label>
     </div>
-    <div class="mb-3">
-      <label class="form-label">Total sin impuesto
-        <input type="number" step="0.01" name="amount" class="form-control" value="{{ invoice.amount }}" required>
-      </label>
+    <div class="row g-3 justify-content-end mb-3">
+      <div class="col-sm-6 ms-auto">
+        <label class="form-label w-100">Total sin impuesto
+          <input type="number" step="0.01" name="amount" class="form-control text-end" value="{{ invoice.amount }}" required>
+        </label>
+      </div>
     </div>
     <div class="mb-3">
       <div class="tax-line">
         <span class="form-label tax-label mb-0">IVA</span>
         <div class="tax-field">
           <span class="tax-symbol tax-symbol-percent">%</span>
-          <input type="number" step="0.01" name="iva_percent" class="form-control tax-percent text-end" value="{{ invoice.iva_percent }}">
+          <input type="number" step="0.01" name="iva_percent" class="form-control tax-percent text-end" value="{{ invoice.iva_percent }}" aria-label="Porcentaje de IVA">
         </div>
         <div class="tax-field tax-field-amount">
           <span class="tax-symbol tax-symbol-currency">$</span>
-          <input type="text" name="iva_amount" class="form-control tax-amount text-end" value="{{ invoice.iva_amount }}" readonly>
+          <input type="text" name="iva_amount" class="form-control tax-amount text-end" value="{{ invoice.iva_amount }}" aria-label="Monto de IVA">
         </div>
       </div>
     </div>
@@ -41,11 +45,11 @@
         <span class="form-label tax-label mb-0">SIRCREB</span>
         <div class="tax-field">
           <span class="tax-symbol tax-symbol-percent">%</span>
-          <input type="number" step="0.01" name="iibb_percent" class="form-control tax-percent text-end" value="{{ invoice.iibb_percent }}">
+          <input type="number" step="0.01" name="iibb_percent" class="form-control tax-percent text-end" value="{{ invoice.iibb_percent }}" aria-label="Porcentaje de SIRCREB">
         </div>
         <div class="tax-field tax-field-amount">
           <span class="tax-symbol tax-symbol-currency">$</span>
-          <input type="text" name="iibb_amount" class="form-control tax-amount text-end" value="{{ invoice.iibb_amount }}" readonly>
+          <input type="text" name="iibb_amount" class="form-control tax-amount text-end" value="{{ invoice.iibb_amount }}" aria-label="Monto de SIRCREB">
         </div>
       </div>
     </div>
@@ -64,5 +68,9 @@
 {% endblock %}
 
 {% block scripts %}
+<script id="invoice-data" type="application/json">{{ invoice|tojson }}</script>
+{% if account %}
+<script id="account-data" type="application/json">{{ account|tojson }}</script>
+{% endif %}
 <script type="module" src="/static/js/invoice_edit.js?v=1"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- align the invoice editing modal and page with the creation modal layout and remove read-only tax amount fields so they can be overridden
- overhaul the invoice edit script to reuse the manual tax editing logic, showing MOD when overriding values and submitting manual amounts
- provide JSON-encoded invoice/account data from the edit route for the shared script

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9d5b289c4833286feb52b9d442e9d