### PR TITLE
Aplicar máscara de moneda y alinear etiquetas de impuestos en modal de factura

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -9,8 +9,9 @@ body {
 }
 
 .tax-label {
-  min-width: 3.5rem;
+  flex: 0 0 7rem;
   margin-right: 0.75rem;
+  text-align: right;
 }
 
 .tax-field {

--- a/app/static/js/invoice_edit.js
+++ b/app/static/js/invoice_edit.js
@@ -175,7 +175,14 @@ function populateForm(inv, acc) {
   form.date.value = inv.date || '';
   form.number.value = inv.number || '';
   form.description.value = inv.description || '';
-  amountInput.value = toNumberString(inv.amount);
+  const amountRaw = inv.amount ?? '';
+  const hasAmountValue = String(amountRaw).trim() !== '';
+  if (hasAmountValue) {
+    const baseAmount = Math.abs(parseDecimal(amountRaw));
+    amountInput.value = formatTaxAmount(baseAmount);
+  } else {
+    amountInput.value = '';
+  }
   const ivaPercent = toNumberString(inv.iva_percent);
   const ivaAmount = parseDecimal(inv.iva_amount ?? 0);
   clearManualPercent(ivaPercentInput, ivaAmountInput, ivaPercent);
@@ -241,7 +248,14 @@ if (modalEl && invoice) {
 }
 
 amountInput.addEventListener('input', () => {
+  sanitizeDecimalInput(amountInput);
   recalcTaxes();
+});
+
+amountInput.addEventListener('blur', () => {
+  if (!amountInput.value.trim()) return;
+  const value = Math.abs(parseDecimal(amountInput.value));
+  amountInput.value = formatTaxAmount(value);
 });
 
 ivaPercentInput.addEventListener('focus', () => {

--- a/app/templates/invoice_detail.html
+++ b/app/templates/invoice_detail.html
@@ -70,13 +70,19 @@
           <div class="row g-3 justify-content-end mb-3">
             <div class="col-sm-6 ms-auto">
               <label class="form-label w-100">Total sin impuesto
-                <input type="number" step="0.01" name="amount" class="form-control text-end" required>
+                <input
+                  type="text"
+                  name="amount"
+                  inputmode="decimal"
+                  class="form-control text-end"
+                  required
+                >
               </label>
             </div>
           </div>
           <div class="mb-3">
             <div class="tax-line">
-              <span class="form-label tax-label mb-0">IVA</span>
+              <span class="form-label tax-label mb-0 text-end">IVA %</span>
               <div class="tax-field">
                 <span class="tax-symbol tax-symbol-percent">%</span>
                 <input type="number" step="0.01" name="iva_percent" class="form-control tax-percent text-end" value="21" aria-label="Porcentaje de IVA">
@@ -89,7 +95,7 @@
           </div>
           <div id="iibb-row" class="mb-3 d-none">
             <div class="tax-line">
-              <span class="form-label tax-label mb-0">SIRCREB</span>
+              <span class="form-label tax-label mb-0 text-end">SIRCREB %</span>
               <div class="tax-field">
                 <span class="tax-symbol tax-symbol-percent">%</span>
                 <input type="number" step="0.01" name="iibb_percent" class="form-control tax-percent text-end" value="3" aria-label="Porcentaje de SIRCREB">


### PR DESCRIPTION
## Summary
- aplica formateo con máscara de moneda al campo de monto sin impuestos del modal de facturas
- actualiza las etiquetas de IVA y SIRCREB para mantener la alineación de los campos del modal
- ajusta el ancho fijo de las etiquetas de impuestos para armonizar la vista del formulario

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9eba46cd083328bef3ed926e2329e