### PR TITLE
Improve tax line alignment in invoice modal

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -5,23 +5,28 @@ body {
 .tax-line {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  gap: 1rem;
+  flex-wrap: nowrap;
 }
 
 .tax-label {
-  flex: 0 0 7rem;
-  margin-right: 0.75rem;
+  flex: 0 0 auto;
+  min-width: 11rem;
+  margin-right: 0;
   text-align: right;
+  white-space: nowrap;
 }
 
 .tax-field {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  white-space: nowrap;
 }
 
 .tax-field-amount {
-  margin-left: 5ch;
+  flex: 1 1 auto;
+  margin-left: 0;
 }
 
 .tax-line .form-control {
@@ -36,6 +41,23 @@ body {
 .tax-line .tax-amount {
   flex: 1 1 8rem;
   min-width: 0;
+}
+
+@media (max-width: 576px) {
+  .tax-line {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .tax-label {
+    min-width: 0;
+    flex-basis: 100%;
+    text-align: left;
+  }
+
+  .tax-field-amount {
+    flex-basis: 100%;
+  }
 }
 
 .tax-symbol {


### PR DESCRIPTION
## Summary
- adjust the tax-line layout styles so labels, percentage fields, and amount fields stay aligned on a single row
- tweak spacing and add a responsive fallback to keep the form legible on smaller screens

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9faa253b88332a1bde76cfeada90a