### PR TITLE
Keep tax rows aligned within invoice modal

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -3,39 +3,64 @@ body {
 }
 
 .tax-line {
-  display: flex;
+  display: grid;
+  grid-template-columns: max-content minmax(4.75rem, 5.5rem) minmax(0, 1fr);
   align-items: center;
-  flex-wrap: wrap;
+  column-gap: 0.75rem;
+  width: 100%;
 }
 
 .tax-label {
-  flex: 0 0 7rem;
-  margin-right: 0.75rem;
-  text-align: right;
+  text-align: left;
+  white-space: nowrap;
 }
 
 .tax-field {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
-  gap: 0.5rem;
+  column-gap: 0.5rem;
+  width: 100%;
 }
 
 .tax-field-amount {
-  margin-left: 5ch;
+  grid-column: 3;
 }
 
 .tax-line .form-control {
-  width: auto;
+  width: 100%;
+  min-width: 0;
 }
 
 .tax-line .tax-percent {
-  flex: 0 0 4.5rem;
-  max-width: 4.5rem;
+  width: 100%;
+  max-width: none;
 }
 
 .tax-line .tax-amount {
-  flex: 1 1 8rem;
+  width: 100%;
   min-width: 0;
+}
+
+@media (max-width: 576px) {
+  .tax-line {
+    grid-template-columns: 1fr;
+    row-gap: 0.75rem;
+  }
+
+  .tax-label {
+    white-space: normal;
+  }
+
+  .tax-field,
+  .tax-field-amount {
+    grid-column: auto;
+    width: 100%;
+  }
+
+  .tax-field {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
 }
 
 .tax-symbol {


### PR DESCRIPTION
## Summary
- replace the flex-based tax-line layout with a grid so labels, percentage inputs, and amount inputs align cleanly within the modal width
- stretch the numeric inputs to their grid columns and preserve a mobile fallback that stacks fields without overflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9faa253b88332a1bde76cfeada90a