### PR TITLE
Fix manual tax field placeholder and add favicon

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -37,6 +37,12 @@ body {
   max-width: none;
 }
 
+.tax-percent.manual-value::placeholder {
+  color: #0d6efd;
+  font-weight: 600;
+  opacity: 0.8;
+}
+
 .tax-line .tax-amount {
   width: 100%;
   min-width: 0;

--- a/app/static/js/billing.js
+++ b/app/static/js/billing.js
@@ -28,19 +28,33 @@ function formatTaxAmount(value) {
 }
 
 function isManualPercent(input) {
-  return input.dataset.manual === 'true';
+  return input?.dataset.manual === 'true';
+}
+
+function showManualPlaceholder(input) {
+  if (!input) return;
+  input.placeholder = 'MOD';
+  input.classList.add('manual-value');
+}
+
+function hideManualPlaceholder(input) {
+  if (!input) return;
+  input.placeholder = '';
+  input.classList.remove('manual-value');
 }
 
 function setManualPercent(percentInput, amountInput, percentValue) {
   percentInput.dataset.manual = 'true';
   percentInput.dataset.manualPercent = String(percentValue ?? 0);
-  percentInput.value = 'MOD';
+  percentInput.value = '';
+  showManualPlaceholder(percentInput);
   amountInput.dataset.manual = 'true';
 }
 
 function clearManualPercent(percentInput, amountInput, fallbackPercent = null) {
   let manualStored = null;
-  if (isManualPercent(percentInput)) {
+  const wasManual = isManualPercent(percentInput);
+  if (wasManual) {
     manualStored = percentInput.dataset.manualPercent ?? null;
     delete percentInput.dataset.manual;
     delete percentInput.dataset.manualPercent;
@@ -48,7 +62,8 @@ function clearManualPercent(percentInput, amountInput, fallbackPercent = null) {
   if (amountInput.dataset.manual === 'true') {
     delete amountInput.dataset.manual;
   }
-  if (percentInput.value === 'MOD') {
+  if (wasManual) {
+    hideManualPlaceholder(percentInput);
     const nextValue = fallbackPercent ?? manualStored;
     percentInput.value =
       nextValue !== null && nextValue !== undefined && nextValue !== ''
@@ -175,6 +190,7 @@ amountInput.addEventListener('blur', () => {
 
 ivaPercentInput.addEventListener('focus', () => {
   if (!isManualPercent(ivaPercentInput)) return;
+  hideManualPlaceholder(ivaPercentInput);
   const percent = parseDecimal(ivaPercentInput.dataset.manualPercent);
   ivaPercentInput.value = percent ? percent.toFixed(2) : '0.00';
   ivaPercentInput.select();
@@ -182,7 +198,8 @@ ivaPercentInput.addEventListener('focus', () => {
 
 ivaPercentInput.addEventListener('blur', () => {
   if (isManualPercent(ivaPercentInput)) {
-    ivaPercentInput.value = 'MOD';
+    ivaPercentInput.value = '';
+    showManualPlaceholder(ivaPercentInput);
   }
 });
 
@@ -216,6 +233,7 @@ ivaAmountInput.addEventListener('blur', () => {
 
 iibbPercentInput.addEventListener('focus', () => {
   if (iibbPercentInput.disabled || !isManualPercent(iibbPercentInput)) return;
+  hideManualPlaceholder(iibbPercentInput);
   const percent = parseDecimal(iibbPercentInput.dataset.manualPercent);
   iibbPercentInput.value = percent ? percent.toFixed(2) : '0.00';
   iibbPercentInput.select();
@@ -224,7 +242,8 @@ iibbPercentInput.addEventListener('focus', () => {
 iibbPercentInput.addEventListener('blur', () => {
   if (iibbPercentInput.disabled) return;
   if (isManualPercent(iibbPercentInput)) {
-    iibbPercentInput.value = 'MOD';
+    iibbPercentInput.value = '';
+    showManualPlaceholder(iibbPercentInput);
   }
 });
 

--- a/app/static/js/invoice_edit.js
+++ b/app/static/js/invoice_edit.js
@@ -11,18 +11,32 @@ function isManualPercent(percentInput) {
   return percentInput?.dataset.manual === 'true';
 }
 
+function showManualPlaceholder(percentInput) {
+  if (!percentInput) return;
+  percentInput.placeholder = 'MOD';
+  percentInput.classList.add('manual-value');
+}
+
+function hideManualPlaceholder(percentInput) {
+  if (!percentInput) return;
+  percentInput.placeholder = '';
+  percentInput.classList.remove('manual-value');
+}
+
 function setManualPercent(percentInput, amountInput, percentValue) {
   if (!percentInput || !amountInput) return;
   percentInput.dataset.manual = 'true';
   percentInput.dataset.manualPercent = String(percentValue ?? 0);
-  percentInput.value = 'MOD';
+  percentInput.value = '';
+  showManualPlaceholder(percentInput);
   amountInput.dataset.manual = 'true';
 }
 
 function clearManualPercent(percentInput, amountInput, fallbackPercent = null) {
   if (!percentInput || !amountInput) return;
   let manualStored = null;
-  if (isManualPercent(percentInput)) {
+  const wasManual = isManualPercent(percentInput);
+  if (wasManual) {
     manualStored = percentInput.dataset.manualPercent ?? null;
     delete percentInput.dataset.manual;
     delete percentInput.dataset.manualPercent;
@@ -30,7 +44,8 @@ function clearManualPercent(percentInput, amountInput, fallbackPercent = null) {
   if (amountInput.dataset.manual === 'true') {
     delete amountInput.dataset.manual;
   }
-  if (percentInput.value === 'MOD') {
+  if (wasManual) {
+    hideManualPlaceholder(percentInput);
     const nextValue = fallbackPercent ?? manualStored;
     percentInput.value =
       nextValue !== null && nextValue !== undefined && nextValue !== ''
@@ -228,6 +243,7 @@ amountInput.addEventListener('blur', () => {
 
 ivaPercentInput.addEventListener('focus', () => {
   if (!isManualPercent(ivaPercentInput)) return;
+  hideManualPlaceholder(ivaPercentInput);
   const percent = parseDecimal(ivaPercentInput.dataset.manualPercent);
   ivaPercentInput.value = percent ? percent.toFixed(2) : '0.00';
   ivaPercentInput.select();
@@ -235,7 +251,8 @@ ivaPercentInput.addEventListener('focus', () => {
 
 ivaPercentInput.addEventListener('blur', () => {
   if (isManualPercent(ivaPercentInput)) {
-    ivaPercentInput.value = 'MOD';
+    ivaPercentInput.value = '';
+    showManualPlaceholder(ivaPercentInput);
   }
 });
 
@@ -270,6 +287,7 @@ ivaAmountInput.addEventListener('blur', () => {
 if (iibbPercentInput) {
   iibbPercentInput.addEventListener('focus', () => {
     if (iibbPercentInput.disabled || !isManualPercent(iibbPercentInput)) return;
+    hideManualPlaceholder(iibbPercentInput);
     const percent = parseDecimal(iibbPercentInput.dataset.manualPercent);
     iibbPercentInput.value = percent ? percent.toFixed(2) : '0.00';
     iibbPercentInput.select();
@@ -278,7 +296,8 @@ if (iibbPercentInput) {
   iibbPercentInput.addEventListener('blur', () => {
     if (iibbPercentInput.disabled) return;
     if (isManualPercent(iibbPercentInput)) {
-      iibbPercentInput.value = 'MOD';
+      iibbPercentInput.value = '';
+      showManualPlaceholder(iibbPercentInput);
     }
   });
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/static/css/layout.css">
+  <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='images/favicon.ico') }}">
   {% block head_extras %}{% endblock %}
 </head>
 <body class="d-flex flex-column min-vh-100">


### PR DESCRIPTION
## Summary
- stop using the literal value `MOD` in tax percent inputs so browsers no longer warn about unparsable numbers and rely on a placeholder-based indicator instead
- add styling for the manual indicator placeholder in the tax percent fields
- wire the shared base template to serve the favicon from the static images directory

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca0232751c833292d266171ad76217