### PR TITLE
Rename retenciones references to percepciones

### DIFF
--- a/app/static/js/accounts.js
+++ b/app/static/js/accounts.js
@@ -69,7 +69,7 @@ async function toggleDetails(row, acc) {
     html += `<p><strong>IVA Ventas:</strong> <span class="text-danger">${symbol} ${formatCurrency(summary.iva_sales)}</span></p>`;
     html += `<p><strong>Balance IVA:</strong> <span class="text-dark fst-italic">${symbol} ${formatCurrency(ivaBalance)}</span></p>`;
     html += `<p><strong>SIRCREB:</strong> <span class="text-danger">${symbol} ${formatCurrency(summary.iibb)}</span></p>`;
-    html += `<p><strong>Retenciones y otros:</strong> <span class="text-success">${symbol} ${formatCurrency(summary.retenciones)}</span></p>`;
+    html += `<p><strong>Percepciones y otros:</strong> <span class="text-success">${symbol} ${formatCurrency(summary.retenciones)}</span></p>`;
     html += '</div>';
   }
   html += '</div>';

--- a/app/templates/billing.html
+++ b/app/templates/billing.html
@@ -76,10 +76,10 @@
             </div>
             <div id="ret-row" class="mb-3 d-none">
               <div class="tax-line">
-                <span class="form-label tax-label mb-0">Retenciones y otros</span>
+                <span class="form-label tax-label mb-0">Percepciones y otros</span>
                 <div class="tax-field tax-field-amount">
                   <span class="tax-symbol tax-symbol-currency">$</span>
-                  <input type="text" name="retenciones" class="form-control tax-amount text-end" aria-label="Monto de Retenciones y otros">
+                  <input type="text" name="retenciones" class="form-control tax-amount text-end" aria-label="Monto de Percepciones y otros">
                 </div>
               </div>
             </div>

--- a/app/templates/invoice_detail.html
+++ b/app/templates/invoice_detail.html
@@ -23,7 +23,7 @@
       <tr><th>SIRCREB % {{ invoice.iibb_percent }}</th><td class="amount">{{ symbol }} {{ invoice.iibb_amount|money }}</td></tr>
       {% endif %}
       {% if invoice.type == 'purchase' %}
-      <tr><th>Retenciones y otros</th><td class="amount">{{ symbol }} {{ invoice.retenciones|money }}</td></tr>
+      <tr><th>Percepciones y otros</th><td class="amount">{{ symbol }} {{ invoice.retenciones|money }}</td></tr>
       {% endif %}
       <tr class="total"><th>Total</th><td class="amount">{{ symbol }} {{ total|money }}</td></tr>
     </tbody>
@@ -98,10 +98,10 @@
           </div>
           <div id="ret-row" class="mb-3 d-none">
             <div class="tax-line">
-              <span class="form-label tax-label mb-0 text-end">Retenciones y otros</span>
+              <span class="form-label tax-label mb-0 text-end">Percepciones y otros</span>
               <div class="tax-field tax-field-amount">
                 <span class="tax-symbol tax-symbol-currency">$</span>
-                <input type="text" name="retenciones" class="form-control tax-amount text-end" aria-label="Monto de retenciones y otros">
+                <input type="text" name="retenciones" class="form-control tax-amount text-end" aria-label="Monto de Percepciones y otros">
               </div>
             </div>
           </div>

--- a/app/templates/invoice_edit.html
+++ b/app/templates/invoice_edit.html
@@ -49,10 +49,10 @@
     </div>
     <div id="ret-row" class="mb-3{% if invoice.type != 'purchase' %} d-none{% endif %}">
       <div class="tax-line">
-        <span class="form-label tax-label mb-0">Retenciones y otros</span>
+        <span class="form-label tax-label mb-0">Percepciones y otros</span>
         <div class="tax-field tax-field-amount">
           <span class="tax-symbol tax-symbol-currency">$</span>
-          <input type="text" name="retenciones" class="form-control tax-amount text-end" value="{{ invoice.retenciones }}" aria-label="Monto de retenciones y otros">
+          <input type="text" name="retenciones" class="form-control tax-amount text-end" value="{{ invoice.retenciones }}" aria-label="Monto de Percepciones y otros">
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace the billing and invoice templates to display "Percepciones y otros" in place of the old "Retenciones y otros" labels and aria text
- update the accounts summary JavaScript to use the new "Percepciones y otros" wording

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caedae5ccc8332a8d3db6cbb288d51