### PR TITLE
Rename invoice retention field to percepciones

### DIFF
--- a/app/config/db.py
+++ b/app/config/db.py
@@ -55,27 +55,32 @@ def _apply_schema_upgrades() -> None:
             return
 
         columns = {col["name"] for col in inspector.get_columns("invoices", schema=schema)}
-        if "retenciones" not in columns:
-            table = _qualified_table("invoices")
-            if engine.dialect.name == "postgresql":
+        table = _qualified_table("invoices")
+        if "percepciones" not in columns:
+            if "retenciones" in columns:
                 conn.execute(
-                    text(
-                        f"ALTER TABLE {table} "
-                        "ADD COLUMN retenciones NUMERIC(12, 2) DEFAULT 0 NOT NULL"
-                    )
+                    text(f"ALTER TABLE {table} RENAME COLUMN retenciones TO percepciones")
                 )
             else:
-                conn.execute(
-                    text(
-                        f"ALTER TABLE {table} "
-                        "ADD COLUMN retenciones NUMERIC(12, 2) DEFAULT 0"
+                if engine.dialect.name == "postgresql":
+                    conn.execute(
+                        text(
+                            f"ALTER TABLE {table} "
+                            "ADD COLUMN percepciones NUMERIC(12, 2) DEFAULT 0 NOT NULL"
+                        )
                     )
-                )
+                else:
+                    conn.execute(
+                        text(
+                            f"ALTER TABLE {table} "
+                            "ADD COLUMN percepciones NUMERIC(12, 2) DEFAULT 0"
+                        )
+                    )
 
             conn.execute(
                 text(
-                    f"UPDATE {table} SET retenciones = 0 "
-                    "WHERE retenciones IS NULL"
+                    f"UPDATE {table} SET percepciones = 0 "
+                    "WHERE percepciones IS NULL"
                 )
             )
 

--- a/app/main.py
+++ b/app/main.py
@@ -150,7 +150,7 @@ async def invoice_detail(
         raise HTTPException(status_code=404, detail="Factura no encontrada")
     acc = db.get(Account, inv.account_id)
     symbol = CURRENCY_SYMBOLS.get(acc.currency) if acc else ""
-    total = inv.amount + inv.iva_amount + inv.retenciones
+    total = inv.amount + inv.iva_amount + inv.percepciones
     invoice_data = jsonable_encoder(inv)
     account_data = jsonable_encoder(acc) if acc else None
     return templates.TemplateResponse(

--- a/app/models.py
+++ b/app/models.py
@@ -71,7 +71,7 @@ class Invoice(Base):
     iva_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
     iibb_percent: Mapped[Decimal] = mapped_column(Numeric(5, 2), default=3)
     iibb_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
-    retenciones: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    percepciones: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
     type: Mapped[InvoiceType] = mapped_column(SqlEnum(InvoiceType), nullable=False)
     account_id: Mapped[int] = mapped_column(ForeignKey("accounts.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/app/routes/accounts.py
+++ b/app/routes/accounts.py
@@ -169,10 +169,10 @@ def account_balances(to_date: date | None = None, db: Session = Depends(get_db))
             ).label("iibb"),
             func.coalesce(
                 func.sum(
-                    case((Invoice.type == InvoiceType.PURCHASE, Invoice.retenciones), else_=0)
+                    case((Invoice.type == InvoiceType.PURCHASE, Invoice.percepciones), else_=0)
                 ),
                 0,
-            ).label("retenciones"),
+            ).label("percepciones"),
         ).group_by(Invoice.account_id)
     )
     tax_rows = db.execute(tax_stmt).all()
@@ -189,7 +189,7 @@ def account_balances(to_date: date | None = None, db: Session = Depends(get_db))
                     - taxes.iva_sale
                     - taxes.iibb
                     + taxes.iva_pur
-                    + taxes.retenciones
+                    + taxes.percepciones
                 )
         balances.append(
             AccountBalance(
@@ -249,7 +249,7 @@ def account_summary(account_id: int, db: Session = Depends(get_db)):
         .group_by(Account.id)
     )
     row = db.execute(stmt).one()
-    iva_pur = iva_sale = iibb = retenciones = Decimal("0")
+    iva_pur = iva_sale = iibb = percepciones = Decimal("0")
     if row.is_billing:
         tax_stmt = (
             select(
@@ -273,10 +273,10 @@ def account_summary(account_id: int, db: Session = Depends(get_db)):
                 ).label("iibb"),
                 func.coalesce(
                     func.sum(
-                        case((Invoice.type == InvoiceType.PURCHASE, Invoice.retenciones), else_=0)
+                        case((Invoice.type == InvoiceType.PURCHASE, Invoice.percepciones), else_=0)
                     ),
                     0,
-                ).label("retenciones"),
+                ).label("percepciones"),
             )
             .where(Invoice.account_id == account_id)
         )
@@ -284,7 +284,7 @@ def account_summary(account_id: int, db: Session = Depends(get_db)):
         iva_pur = tax_row.iva_pur
         iva_sale = tax_row.iva_sale
         iibb = tax_row.iibb
-        retenciones = tax_row.retenciones
+        percepciones = tax_row.percepciones
     return AccountSummary(
         opening_balance=row.opening_balance,
         income_balance=row.income,
@@ -293,7 +293,7 @@ def account_summary(account_id: int, db: Session = Depends(get_db)):
         iva_purchases=iva_pur if row.is_billing else None,
         iva_sales=iva_sale if row.is_billing else None,
         iibb=iibb if row.is_billing else None,
-        retenciones=retenciones if row.is_billing else None,
+        percepciones=percepciones if row.is_billing else None,
     )
 
 

--- a/app/routes/invoices.py
+++ b/app/routes/invoices.py
@@ -45,12 +45,12 @@ def create_invoice(payload: InvoiceCreate, db: Session = Depends(get_db)):
             if payload.iibb_amount is not None
             else Decimal("0")
         )
-    if payload.retenciones is not None:
-        retenciones = abs(payload.retenciones).quantize(Decimal("0.01"))
+    if payload.percepciones is not None:
+        percepciones = abs(payload.percepciones).quantize(Decimal("0.01"))
     else:
-        retenciones = Decimal("0")
+        percepciones = Decimal("0")
     if payload.type == InvoiceType.SALE:
-        retenciones = Decimal("0")
+        percepciones = Decimal("0")
     inv = Invoice(
         account_id=payload.account_id,
         date=payload.date,
@@ -61,7 +61,7 @@ def create_invoice(payload: InvoiceCreate, db: Session = Depends(get_db)):
         iva_amount=iva_amount,
         iibb_percent=iibb_percent,
         iibb_amount=iibb_amount,
-        retenciones=retenciones,
+        percepciones=percepciones,
         type=payload.type,
     )
     db.add(inv)
@@ -111,12 +111,12 @@ def update_invoice(invoice_id: int, payload: InvoiceCreate, db: Session = Depend
             if payload.iibb_amount is not None
             else Decimal("0")
         )
-    if payload.retenciones is not None:
-        retenciones = abs(payload.retenciones).quantize(Decimal("0.01"))
+    if payload.percepciones is not None:
+        percepciones = abs(payload.percepciones).quantize(Decimal("0.01"))
     else:
-        retenciones = Decimal("0")
+        percepciones = Decimal("0")
     if payload.type == InvoiceType.SALE:
-        retenciones = Decimal("0")
+        percepciones = Decimal("0")
     for field in [
         "account_id",
         "date",
@@ -130,7 +130,7 @@ def update_invoice(invoice_id: int, payload: InvoiceCreate, db: Session = Depend
     inv.iva_amount = iva_amount
     inv.iibb_percent = iibb_percent
     inv.iibb_amount = iibb_amount
-    inv.retenciones = retenciones
+    inv.percepciones = percepciones
     db.add(inv)
     db.commit()
     db.refresh(inv)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -51,7 +51,7 @@ class InvoiceCreate(BaseModel):
     iibb_percent: Decimal = Decimal("3")
     iva_amount: Decimal | None = None
     iibb_amount: Decimal | None = None
-    retenciones: Decimal = Decimal("0")
+    percepciones: Decimal = Decimal("0")
     type: InvoiceType
 
 
@@ -66,7 +66,7 @@ class InvoiceOut(BaseModel):
     iva_amount: Decimal
     iibb_percent: Decimal
     iibb_amount: Decimal
-    retenciones: Decimal
+    percepciones: Decimal
     type: InvoiceType
 
     class Config:
@@ -104,7 +104,7 @@ class AccountSummary(BaseModel):
     iva_purchases: Decimal | None = None
     iva_sales: Decimal | None = None
     iibb: Decimal | None = None
-    retenciones: Decimal | None = None
+    percepciones: Decimal | None = None
 
 
 class UserCreate(BaseModel):

--- a/app/static/js/accounts.js
+++ b/app/static/js/accounts.js
@@ -50,9 +50,9 @@ async function toggleDetails(row, acc) {
   const ivaBalance = summary.is_billing
     ? Number(summary.iva_purchases) - Number(summary.iva_sales)
     : 0;
-  const retencionesTotal = summary.is_billing ? Number(summary.retenciones) : 0;
+  const percepcionesTotal = summary.is_billing ? Number(summary.percepciones) : 0;
   const total = summary.is_billing
-    ? balance + ivaBalance - Number(summary.iibb) + retencionesTotal
+    ? balance + ivaBalance - Number(summary.iibb) + percepcionesTotal
     : balance;
 
   let html = '<div class="container text-start">';
@@ -69,7 +69,7 @@ async function toggleDetails(row, acc) {
     html += `<p><strong>IVA Ventas:</strong> <span class="text-danger">${symbol} ${formatCurrency(summary.iva_sales)}</span></p>`;
     html += `<p><strong>Balance IVA:</strong> <span class="text-dark fst-italic">${symbol} ${formatCurrency(ivaBalance)}</span></p>`;
     html += `<p><strong>SIRCREB:</strong> <span class="text-danger">${symbol} ${formatCurrency(summary.iibb)}</span></p>`;
-    html += `<p><strong>Percepciones y otros:</strong> <span class="text-success">${symbol} ${formatCurrency(summary.retenciones)}</span></p>`;
+    html += `<p><strong>Percepciones y otros:</strong> <span class="text-success">${symbol} ${formatCurrency(summary.percepciones)}</span></p>`;
     html += '</div>';
   }
   html += '</div>';

--- a/app/static/js/billing.js
+++ b/app/static/js/billing.js
@@ -17,7 +17,7 @@ const iibbPercentInput = form.iibb_percent;
 const iibbAmountInput = form.iibb_amount;
 const iibbRow = document.getElementById('iibb-row');
 const retRow = document.getElementById('ret-row');
-const retencionesInput = form.retenciones;
+const percepcionesInput = form.percepciones;
 const billingAccountLabel = document.getElementById('billing-account');
 const defaultIvaPercent = ivaPercentInput.value || '21';
 const defaultIibbPercent = iibbPercentInput.value || '3';
@@ -129,10 +129,10 @@ function renderInvoices() {
       case 4:
         // Comparar por monto total (importe sin impuestos + IVA)
         const totalWithIvaA = Math.abs(
-          Number(a.amount) + Number(a.iva_amount) + Number(a.retenciones || 0)
+          Number(a.amount) + Number(a.iva_amount) + Number(a.percepciones || 0)
         );
         const totalWithIvaB = Math.abs(
-          Number(b.amount) + Number(b.iva_amount) + Number(b.retenciones || 0)
+          Number(b.amount) + Number(b.iva_amount) + Number(b.percepciones || 0)
         );
         return sortAsc
           ? totalWithIvaA - totalWithIvaB
@@ -279,15 +279,15 @@ iibbAmountInput.addEventListener('blur', () => {
   iibbAmountInput.value = formatTaxAmount(value);
 });
 
-retencionesInput.addEventListener('input', () => {
-  if (retencionesInput.disabled) return;
-  sanitizeDecimalInput(retencionesInput);
+percepcionesInput.addEventListener('input', () => {
+  if (percepcionesInput.disabled) return;
+  sanitizeDecimalInput(percepcionesInput);
 });
 
-retencionesInput.addEventListener('blur', () => {
-  if (retencionesInput.disabled || !retencionesInput.value.trim()) return;
-  const value = getAmountValue(retencionesInput);
-  retencionesInput.value = formatTaxAmount(value);
+percepcionesInput.addEventListener('blur', () => {
+  if (percepcionesInput.disabled || !percepcionesInput.value.trim()) return;
+  const value = getAmountValue(percepcionesInput);
+  percepcionesInput.value = formatTaxAmount(value);
 });
 
 async function loadMore() {
@@ -325,15 +325,15 @@ function openModal(type) {
   if (retRow) {
     retRow.classList.toggle('d-none', !isPurchase);
   }
-  retencionesInput.disabled = !isPurchase;
-  retencionesInput.value = formatTaxAmount(0);
+  percepcionesInput.disabled = !isPurchase;
+  percepcionesInput.value = formatTaxAmount(0);
   iibbRow.classList.toggle('d-none', isPurchase);
   iibbPercentInput.disabled = isPurchase;
   iibbAmountInput.disabled = isPurchase;
   iibbPercentInput.value = isPurchase ? '0' : defaultIibbPercent;
   iibbAmountInput.value = formatTaxAmount(0);
   if (!isPurchase) {
-    retencionesInput.value = formatTaxAmount(0);
+    percepcionesInput.value = formatTaxAmount(0);
   }
   recalcTaxes();
   invModal.show();
@@ -385,7 +385,7 @@ container.addEventListener('scroll', () => {
     const ivaAmount = roundToTwo(getAmountValue(ivaAmountInput));
     const iibbPercentValue = isPurchase ? 0 : roundToTwo(Math.abs(getPercentValue(iibbPercentInput)));
     const iibbAmount = roundToTwo(getAmountValue(iibbAmountInput));
-    const retencionesAmount = isPurchase ? roundToTwo(getAmountValue(retencionesInput)) : 0;
+    const percepcionesAmount = isPurchase ? roundToTwo(getAmountValue(percepcionesInput)) : 0;
     const payload = {
       date: data.get('date'),
       number: data.get('number'),
@@ -395,7 +395,7 @@ container.addEventListener('scroll', () => {
       type: form.dataset.type,
       iva_percent: ivaPercent,
       iibb_percent: isPurchase ? 0 : iibbPercentValue,
-      retenciones: retencionesAmount
+      percepciones: percepcionesAmount
     };
     if (isManualPercent(ivaPercentInput)) {
       payload.iva_amount = ivaAmount;

--- a/app/static/js/invoice_edit.js
+++ b/app/static/js/invoice_edit.js
@@ -86,7 +86,7 @@ const iibbPercentInput = form.iibb_percent;
 const iibbAmountInput = form.iibb_amount;
 const iibbRow = document.getElementById('iibb-row');
 const retRow = document.getElementById('ret-row');
-const retencionesInput = form.retenciones;
+const percepcionesInput = form.percepciones;
 const billingAccountLabel = document.getElementById('billing-account');
 
 const modalEl = document.getElementById('invModal');
@@ -166,10 +166,10 @@ function populateForm(inv, acc) {
     iibbPercentInput.value = iibbPercent;
     iibbAmountInput.value = formatTaxAmount(iibbAmount);
   }
-  if (retencionesInput) {
-    const retAmount = parseDecimal(inv.retenciones ?? 0);
-    retencionesInput.value = formatTaxAmount(retAmount);
-    retencionesInput.disabled = inv.type !== 'purchase';
+  if (percepcionesInput) {
+    const percAmount = parseDecimal(inv.percepciones ?? 0);
+    percepcionesInput.value = formatTaxAmount(percAmount);
+    percepcionesInput.disabled = inv.type !== 'purchase';
   }
   form.account_id.value = inv.account_id ?? form.account_id.value;
   if (billingAccountLabel && acc) {
@@ -186,8 +186,8 @@ function populateForm(inv, acc) {
   if (iibbPercentInput) {
     iibbPercentInput.disabled = isPurchase;
   }
-  if (retencionesInput && !isPurchase) {
-    retencionesInput.value = formatTaxAmount(0);
+  if (percepcionesInput && !isPurchase) {
+    percepcionesInput.value = formatTaxAmount(0);
   }
   if (iibbAmountInput) {
     iibbAmountInput.disabled = isPurchase;
@@ -224,7 +224,7 @@ if (modalEl && invoice) {
     iva_amount: parseDecimal(ivaAmountInput.value),
     iibb_percent: iibbPercentInput ? parseDecimal(iibbPercentInput.value) : 0,
     iibb_amount: iibbAmountInput ? parseDecimal(iibbAmountInput.value) : 0,
-    retenciones: retencionesInput ? parseDecimal(retencionesInput.value) : 0,
+    percepciones: percepcionesInput ? parseDecimal(percepcionesInput.value) : 0,
     account_id: Number(form.account_id.value)
   };
   populateForm(fallback, account);
@@ -336,16 +336,16 @@ if (iibbAmountInput) {
   });
 }
 
-if (retencionesInput) {
-  retencionesInput.addEventListener('input', () => {
-    if (retencionesInput.disabled) return;
-    sanitizeDecimalInput(retencionesInput);
+if (percepcionesInput) {
+  percepcionesInput.addEventListener('input', () => {
+    if (percepcionesInput.disabled) return;
+    sanitizeDecimalInput(percepcionesInput);
   });
 
-  retencionesInput.addEventListener('blur', () => {
-    if (retencionesInput.disabled || !retencionesInput.value.trim()) return;
-    const value = getAmountValue(retencionesInput);
-    retencionesInput.value = formatTaxAmount(value);
+  percepcionesInput.addEventListener('blur', () => {
+    if (percepcionesInput.disabled || !percepcionesInput.value.trim()) return;
+    const value = getAmountValue(percepcionesInput);
+    percepcionesInput.value = formatTaxAmount(value);
   });
 }
 
@@ -360,7 +360,7 @@ form.addEventListener('submit', async e => {
   const iibbPercentValue =
     type === 'purchase' ? 0 : roundToTwo(Math.abs(getPercentValue(iibbPercentInput)));
   const iibbAmountValue = roundToTwo(getAmountValue(iibbAmountInput));
-  const retencionesValue = type === 'purchase' ? roundToTwo(getAmountValue(retencionesInput)) : 0;
+  const percepcionesValue = type === 'purchase' ? roundToTwo(getAmountValue(percepcionesInput)) : 0;
   const payload = {
     date: data.get('date'),
     number: data.get('number'),
@@ -370,7 +370,7 @@ form.addEventListener('submit', async e => {
     type,
     iva_percent: ivaPercentValue,
     iibb_percent: type === 'purchase' ? 0 : iibbPercentValue,
-    retenciones: retencionesValue
+    percepciones: percepcionesValue
   };
   if (isManualPercent(ivaPercentInput)) {
     payload.iva_amount = ivaAmountValue;
@@ -381,7 +381,7 @@ form.addEventListener('submit', async e => {
     payload.iibb_amount = iibbAmountValue;
   }
   if (type !== 'purchase') {
-    payload.retenciones = 0;
+    payload.percepciones = 0;
   }
   const today = new Date().toISOString().split('T')[0];
   if (payload.date > today) {

--- a/app/static/js/ui.js
+++ b/app/static/js/ui.js
@@ -104,7 +104,7 @@ export function renderInvoice(tbody, inv, accountMap) {
   const typeText = inv.type === 'sale' ? 'Venta' : 'Compra';
   // Monto total calculado como importe sin impuestos más IVA
   const totalWithIva =
-    Number(inv.amount) + Number(inv.iva_amount) + Number(inv.retenciones || 0);
+    Number(inv.amount) + Number(inv.iva_amount) + Number(inv.percepciones || 0);
   const amountColor = inv.type === 'sale' ? 'rgb(40,150,20)' : 'rgb(170,10,10)';
   const amount = formatCurrency(Math.abs(totalWithIva));
   tr.innerHTML =

--- a/app/templates/billing.html
+++ b/app/templates/billing.html
@@ -79,7 +79,7 @@
                 <span class="form-label tax-label mb-0">Percepciones y otros</span>
                 <div class="tax-field tax-field-amount">
                   <span class="tax-symbol tax-symbol-currency">$</span>
-                  <input type="text" name="retenciones" class="form-control tax-amount text-end" aria-label="Monto de Percepciones y otros">
+                  <input type="text" name="percepciones" class="form-control tax-amount text-end" aria-label="Monto de Percepciones y otros">
                 </div>
               </div>
             </div>

--- a/app/templates/invoice_detail.html
+++ b/app/templates/invoice_detail.html
@@ -23,7 +23,7 @@
       <tr><th>SIRCREB % {{ invoice.iibb_percent }}</th><td class="amount">{{ symbol }} {{ invoice.iibb_amount|money }}</td></tr>
       {% endif %}
       {% if invoice.type == 'purchase' %}
-      <tr><th>Percepciones y otros</th><td class="amount">{{ symbol }} {{ invoice.retenciones|money }}</td></tr>
+      <tr><th>Percepciones y otros</th><td class="amount">{{ symbol }} {{ invoice.percepciones|money }}</td></tr>
       {% endif %}
       <tr class="total"><th>Total</th><td class="amount">{{ symbol }} {{ total|money }}</td></tr>
     </tbody>
@@ -101,7 +101,7 @@
               <span class="form-label tax-label mb-0 text-end">Percepciones y otros</span>
               <div class="tax-field tax-field-amount">
                 <span class="tax-symbol tax-symbol-currency">$</span>
-                <input type="text" name="retenciones" class="form-control tax-amount text-end" aria-label="Monto de Percepciones y otros">
+                <input type="text" name="percepciones" class="form-control tax-amount text-end" aria-label="Monto de Percepciones y otros">
               </div>
             </div>
           </div>

--- a/app/templates/invoice_edit.html
+++ b/app/templates/invoice_edit.html
@@ -52,7 +52,7 @@
         <span class="form-label tax-label mb-0">Percepciones y otros</span>
         <div class="tax-field tax-field-amount">
           <span class="tax-symbol tax-symbol-currency">$</span>
-          <input type="text" name="retenciones" class="form-control tax-amount text-end" value="{{ invoice.retenciones }}" aria-label="Monto de Percepciones y otros">
+          <input type="text" name="percepciones" class="form-control tax-amount text-end" value="{{ invoice.percepciones }}" aria-label="Monto de Percepciones y otros">
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- rename the invoice tax column from retenciones to percepciones in the ORM and database upgrade helper
- update FastAPI schemas, routes, and main view logic to use the new percepciones field
- align templates and front-end JavaScript so forms and totals read and write percepciones consistently

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cadfafb100833287babdf602a67a43