### PR TITLE
Add retention certificate documents

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -81,6 +81,29 @@ class Invoice(Base):
     account = relationship("Account", back_populates="invoices")
 
 
+class RetentionCertificate(Base):
+    __tablename__ = "retention_certificates"
+    __table_args__ = (
+        Index(
+            "ix_retention_certificates_date_id",
+            "date",
+            "id",
+        ),
+        CheckConstraint(
+            "amount <> 0", name="ck_retention_certificates_amount_nonzero"
+        ),
+    )
+    id: Mapped[int] = mapped_column(primary_key=True)
+    number: Mapped[str] = mapped_column(String(50), nullable=False)
+    date: Mapped[date] = mapped_column(Date, nullable=False)
+    invoice_reference: Mapped[str] = mapped_column(String(50), nullable=False)
+    concept: Mapped[str] = mapped_column(Text, nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
 class FrequentTransaction(Base):
     __tablename__ = "frequent_transactions"
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/app/routes/certificates.py
+++ b/app/routes/certificates.py
@@ -1,0 +1,94 @@
+from datetime import date
+from decimal import Decimal
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import Response
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from auth import require_admin
+from config.db import get_db
+from models import RetentionCertificate
+from schemas import RetentionCertificateCreate, RetentionCertificateOut
+
+router = APIRouter(prefix="/retention-certificates")
+
+
+@router.post("", response_model=RetentionCertificateOut)
+def create_certificate(
+    payload: RetentionCertificateCreate, db: Session = Depends(get_db)
+):
+    if payload.date > date.today():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No se permiten fechas futuras",
+        )
+    amount = abs(payload.amount).quantize(Decimal("0.01"))
+    cert = RetentionCertificate(
+        number=payload.number,
+        date=payload.date,
+        invoice_reference=payload.invoice_reference,
+        concept=payload.concept,
+        amount=amount,
+    )
+    db.add(cert)
+    db.commit()
+    db.refresh(cert)
+    return cert
+
+
+@router.get("", response_model=List[RetentionCertificateOut])
+def list_certificates(
+    limit: int = 100, offset: int = 0, db: Session = Depends(get_db)
+):
+    stmt = (
+        select(RetentionCertificate)
+        .order_by(RetentionCertificate.date.desc(), RetentionCertificate.id.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    return db.scalars(stmt).all()
+
+
+@router.put(
+    "/{certificate_id}",
+    response_model=RetentionCertificateOut,
+    dependencies=[Depends(require_admin)],
+)
+def update_certificate(
+    certificate_id: int,
+    payload: RetentionCertificateCreate,
+    db: Session = Depends(get_db),
+):
+    cert = db.get(RetentionCertificate, certificate_id)
+    if not cert:
+        raise HTTPException(status_code=404, detail="Certificado no encontrado")
+    if payload.date > date.today():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No se permiten fechas futuras",
+        )
+    amount = abs(payload.amount).quantize(Decimal("0.01"))
+    cert.number = payload.number
+    cert.date = payload.date
+    cert.invoice_reference = payload.invoice_reference
+    cert.concept = payload.concept
+    cert.amount = amount
+    db.add(cert)
+    db.commit()
+    db.refresh(cert)
+    return cert
+
+
+@router.delete(
+    "/{certificate_id}",
+    status_code=204,
+    dependencies=[Depends(require_admin)],
+)
+def delete_certificate(certificate_id: int, db: Session = Depends(get_db)):
+    cert = db.get(RetentionCertificate, certificate_id)
+    if cert:
+        db.delete(cert)
+        db.commit()
+    return Response(status_code=204)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -73,6 +73,21 @@ class InvoiceOut(BaseModel):
         from_attributes = True
 
 
+class RetentionCertificateCreate(BaseModel):
+    number: str
+    date: date
+    invoice_reference: str
+    concept: str
+    amount: Decimal
+
+
+class RetentionCertificateOut(RetentionCertificateCreate):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
 class FrequentIn(BaseModel):
     description: str
 

--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -195,10 +195,66 @@ body {
   border: none;
 }
 
-#menu-button {
+#cert-table-wrapper {
+  border: 1px solid #d0d0d0;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+}
+
+#cert-table {
+  width: 100%;
+  table-layout: fixed;
+  border: none;
+  font-size: calc(1rem + 2pt);
+  --bs-table-striped-bg: #f0f8ff;
+  --bs-table-bg: #ffffff;
+  box-shadow: none;
+}
+
+#cert-table .col-number {
+  width: 14ch;
+}
+
+#cert-table .col-date {
+  width: 15ch;
+}
+
+#cert-table .col-ref {
+  width: 18ch;
+}
+
+#cert-table .col-amount {
+  width: 18ch;
+}
+
+#cert-table .col-actions {
+  width: 12ch;
+}
+
+#cert-table thead {
+  --bs-table-bg: #e9ecef;
+}
+
+#cert-table thead th {
+  text-transform: uppercase;
+  font-size: calc(1.1rem + 2pt);
+  border-bottom: none;
+}
+
+#cert-table th,
+#cert-table td {
+  border: none;
+}
+
+#header-left {
   left: 4rem;
   top: 50%;
   transform: translateY(-50%);
+  gap: 1rem;
+}
+
+#menu-button {
   width: 3.5rem;
   height: 3.5rem;
   padding: 0;
@@ -208,8 +264,25 @@ body {
 }
 
 #menu-button:hover {
-  transform: translateY(calc(-50% - 2px));
+  transform: translateY(-2px);
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+}
+
+#more-documents .dropdown-menu {
+  min-width: 16rem;
+}
+
+.header-more-link {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #0d6efd;
+  text-decoration: none;
+}
+
+.header-more-link:hover,
+.header-more-link:focus {
+  color: #0a58ca;
+  text-decoration: underline;
 }
 
 #logo-link {
@@ -316,7 +389,7 @@ body {
   #table-container {
     padding: 1rem;
   }
-  #menu-button {
+  #header-left {
     left: 1rem;
   }
   #logo-link {
@@ -340,6 +413,15 @@ body {
   #inv-table .col-type,
   #inv-table .col-desc,
   #inv-table .col-amount {
+    width: auto;
+  }
+
+  #cert-table .col-number,
+  #cert-table .col-date,
+  #cert-table .col-ref,
+  #cert-table .col-concept,
+  #cert-table .col-amount,
+  #cert-table .col-actions {
     width: auto;
   }
 }

--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -13,6 +13,11 @@ export async function fetchInvoices(limit, offset) {
   return res.json();
 }
 
+export async function fetchRetentionCertificates(limit, offset) {
+  const res = await fetch(`/retention-certificates?limit=${limit}&offset=${offset}`);
+  return res.json();
+}
+
 export async function fetchAccountBalances() {
   const res = await fetch('/accounts/balances');
   return res.json();
@@ -104,6 +109,61 @@ export async function updateInvoice(id, payload) {
 
 export async function deleteInvoice(id) {
   const res = await fetch(`/invoices/${id}`, { method: 'DELETE' });
+  if (res.ok) return { ok: true };
+  let error = 'Error al eliminar';
+  try {
+    const data = await res.json();
+    error = data.detail || error;
+  } catch (_) {}
+  return { ok: false, error };
+}
+
+export async function createRetentionCertificate(payload) {
+  const res = await fetch('/retention-certificates', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (res.ok) {
+    const certificate = await res.json();
+    return { ok: true, certificate };
+  }
+  let error = 'Error al guardar';
+  try {
+    const data = await res.json();
+    if (Array.isArray(data.detail)) {
+      error = data.detail.map(d => d.msg).join(', ');
+    } else {
+      error = data.detail || error;
+    }
+  } catch (_) {}
+  return { ok: false, error };
+}
+
+export async function updateRetentionCertificate(id, payload) {
+  const res = await fetch(`/retention-certificates/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (res.ok) {
+    const certificate = await res.json();
+    return { ok: true, certificate };
+  }
+  let error = 'Error al guardar';
+  try {
+    const data = await res.json();
+    if (Array.isArray(data.detail)) {
+      error = data.detail.map(d => d.msg).join(', ');
+    } else {
+      error = data.detail || error;
+    }
+  } catch (_) {}
+  return { ok: false, error };
+}
+
+export async function deleteRetentionCertificate(id) {
+  const res = await fetch(`/retention-certificates/${id}`, { method: 'DELETE' });
   if (res.ok) return { ok: true };
   let error = 'Error al eliminar';
   try {

--- a/app/static/js/cert_retencion.js
+++ b/app/static/js/cert_retencion.js
@@ -1,0 +1,250 @@
+import {
+  fetchRetentionCertificates,
+  createRetentionCertificate,
+  updateRetentionCertificate,
+  deleteRetentionCertificate
+} from './api.js?v=1';
+import { formatCurrency, showOverlay, hideOverlay } from './ui.js?v=1';
+import { sanitizeDecimalInput, parseDecimal } from './money.js?v=1';
+import { CURRENCY_SYMBOLS } from './constants.js';
+
+const tbody = document.querySelector('#cert-table tbody');
+const addBtn = document.getElementById('add-certificate');
+const searchBox = document.getElementById('search-box');
+const modalEl = document.getElementById('certModal');
+const certModal = new bootstrap.Modal(modalEl);
+const form = document.getElementById('cert-form');
+const modalTitle = document.getElementById('cert-form-title');
+const alertBox = document.getElementById('cert-alert');
+const amountInput = form.amount;
+const isAdmin = Boolean(window.isAdmin);
+const currencyCode = window.certCurrency || 'ARS';
+const currencySymbol = CURRENCY_SYMBOLS[currencyCode] || '';
+
+let certificates = [];
+
+function normalizeCertificate(cert) {
+  return {
+    ...cert,
+    amount: Number(cert.amount)
+  };
+}
+
+function formatDate(value) {
+  const dateObj = new Date(value);
+  if (Number.isNaN(dateObj.getTime())) return value;
+  return dateObj
+    .toLocaleDateString('es-ES', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric'
+    })
+    .replace('.', '');
+}
+
+function renderCertificates() {
+  const query = searchBox.value.trim().toLowerCase();
+  const filtered = certificates.filter(cert => {
+    const number = cert.number?.toLowerCase() || '';
+    const invoiceRef = cert.invoice_reference?.toLowerCase() || '';
+    const concept = cert.concept?.toLowerCase() || '';
+    return (
+      number.includes(query) ||
+      invoiceRef.includes(query) ||
+      concept.includes(query)
+    );
+  });
+  filtered.sort((a, b) => {
+    if (a.date === b.date) {
+      return b.id - a.id;
+    }
+    return new Date(b.date) - new Date(a.date);
+  });
+  tbody.innerHTML = '';
+  filtered.forEach(cert => {
+    const tr = document.createElement('tr');
+    tr.dataset.id = cert.id;
+
+    const numberTd = document.createElement('td');
+    numberTd.className = 'text-center';
+    numberTd.textContent = cert.number;
+
+    const dateTd = document.createElement('td');
+    dateTd.className = 'text-center';
+    dateTd.textContent = formatDate(cert.date);
+
+    const refTd = document.createElement('td');
+    refTd.className = 'text-center';
+    refTd.textContent = cert.invoice_reference;
+
+    const conceptTd = document.createElement('td');
+    conceptTd.textContent = cert.concept;
+
+    const amountTd = document.createElement('td');
+    amountTd.className = 'text-end';
+    const amountValue = Number.isFinite(cert.amount) ? cert.amount : 0;
+    amountTd.textContent = `${currencySymbol} ${formatCurrency(Math.abs(amountValue))}`;
+
+    tr.append(numberTd, dateTd, refTd, conceptTd, amountTd);
+
+    if (isAdmin) {
+      const actionsTd = document.createElement('td');
+      actionsTd.className = 'text-center text-nowrap';
+
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.className = 'btn btn-sm btn-outline-secondary me-2';
+      editBtn.title = 'Editar';
+      editBtn.innerHTML = '<i class="bi bi-pencil"></i>';
+      editBtn.addEventListener('click', () => openEditModal(cert));
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.className = 'btn btn-sm btn-outline-danger';
+      deleteBtn.title = 'Eliminar';
+      deleteBtn.innerHTML = '<i class="bi bi-x"></i>';
+      deleteBtn.addEventListener('click', () => confirmDelete(cert));
+
+      actionsTd.append(editBtn, deleteBtn);
+      tr.appendChild(actionsTd);
+    }
+
+    tbody.appendChild(tr);
+  });
+}
+
+function setDateLimits() {
+  const today = new Date().toISOString().split('T')[0];
+  form.date.max = today;
+}
+
+function openCreateModal() {
+  form.reset();
+  modalTitle.textContent = 'Nuevo certificado';
+  form.dataset.mode = 'create';
+  delete form.dataset.id;
+  setDateLimits();
+  form.date.value = form.date.max;
+  amountInput.value = '';
+  clearError();
+  certModal.show();
+}
+
+function openEditModal(cert) {
+  form.reset();
+  modalTitle.textContent = 'Editar certificado';
+  form.dataset.mode = 'edit';
+  form.dataset.id = cert.id;
+  setDateLimits();
+  form.date.value = cert.date;
+  form.number.value = cert.number;
+  form.invoice_reference.value = cert.invoice_reference;
+  form.concept.value = cert.concept;
+  amountInput.value = formatCurrency(Math.abs(Number(cert.amount)));
+  clearError();
+  certModal.show();
+}
+
+async function loadCertificates() {
+  showOverlay();
+  try {
+    const data = await fetchRetentionCertificates(200, 0);
+    certificates = Array.isArray(data)
+      ? data.map(normalizeCertificate)
+      : [];
+    renderCertificates();
+  } finally {
+    hideOverlay();
+  }
+}
+
+function showError(message) {
+  alertBox.textContent = message;
+  alertBox.classList.remove('d-none');
+  alertBox.classList.add('alert-danger');
+}
+
+function clearError() {
+  alertBox.classList.add('d-none');
+  alertBox.textContent = '';
+  alertBox.classList.remove('alert-danger');
+}
+
+form.addEventListener('submit', async event => {
+  event.preventDefault();
+  clearError();
+  const mode = form.dataset.mode || 'create';
+  const payload = {
+    date: form.date.value,
+    number: form.number.value.trim(),
+    invoice_reference: form.invoice_reference.value.trim(),
+    concept: form.concept.value.trim()
+  };
+
+  const amountValue = parseDecimal(amountInput.value);
+  if (!Number.isFinite(amountValue) || amountValue <= 0) {
+    showError('Ingrese un monto válido');
+    return;
+  }
+  payload.amount = Math.abs(amountValue).toFixed(2);
+
+  if (!payload.number || !payload.invoice_reference || !payload.concept || !payload.date) {
+    showError('Todos los campos son obligatorios');
+    return;
+  }
+
+  showOverlay();
+  try {
+    let result;
+    if (mode === 'edit') {
+      const id = Number(form.dataset.id);
+      result = await updateRetentionCertificate(id, payload);
+    } else {
+      result = await createRetentionCertificate(payload);
+    }
+    if (!result.ok) {
+      showError(result.error || 'Error al guardar');
+      return;
+    }
+    const saved = normalizeCertificate(result.certificate);
+    if (mode === 'edit') {
+      certificates = certificates.map(cert => (cert.id === saved.id ? saved : cert));
+    } else {
+      certificates.push(saved);
+    }
+    renderCertificates();
+    certModal.hide();
+  } finally {
+    hideOverlay();
+  }
+});
+
+async function confirmDelete(cert) {
+  if (!confirm('¿Eliminar certificado?')) return;
+  showOverlay();
+  try {
+    const result = await deleteRetentionCertificate(cert.id);
+    if (!result.ok) {
+      alert(result.error || 'Error al eliminar');
+      return;
+    }
+    certificates = certificates.filter(item => item.id !== cert.id);
+    renderCertificates();
+  } finally {
+    hideOverlay();
+  }
+}
+
+addBtn.addEventListener('click', openCreateModal);
+searchBox.addEventListener('input', renderCertificates);
+amountInput.addEventListener('input', () => sanitizeDecimalInput(amountInput));
+amountInput.addEventListener('blur', () => {
+  const value = parseDecimal(amountInput.value);
+  if (!value) {
+    amountInput.value = '';
+    return;
+  }
+  amountInput.value = formatCurrency(Math.abs(value));
+});
+
+loadCertificates();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,9 +12,23 @@
 </head>
 <body class="d-flex flex-column min-vh-100">
   <header class="navbar navbar-light bg-light py-3 px-2 justify-content-center position-relative">
-    <button id="menu-button" class="navbar-toggler position-absolute p-0" type="button" data-bs-toggle="offcanvas" data-bs-target="#sideMenu" aria-controls="sideMenu">
-      <span class="navbar-toggler-icon"></span>
-    </button>
+    <div id="header-left" class="position-absolute d-flex align-items-center">
+      <button id="menu-button" class="navbar-toggler p-0" type="button" data-bs-toggle="offcanvas" data-bs-target="#sideMenu" aria-controls="sideMenu">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      {% if more_documents %}
+      <div class="dropdown" id="more-documents">
+        <button class="btn btn-link dropdown-toggle header-more-link" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+          Más Documentos
+        </button>
+        <ul class="dropdown-menu shadow">
+          {% for doc in more_documents %}
+          <li><a class="dropdown-item{% if doc.active %} active{% endif %}" href="{{ doc.url }}"{% if doc.active %} aria-current="page"{% endif %}>{{ doc.label }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endif %}
+    </div>
     <h1 class="h3 m-0">{{ header_title|safe }}</h1>
     <a href="/" id="logo-link" class="position-absolute">
       <img src="/static/images/logo_sqr.png" alt="Logo">
@@ -47,6 +61,9 @@
     <div class="spinner-border text-primary" role="status"></div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+  <script>
+    window.isAdmin = {{ 1 if user and user.is_admin else 0 }};
+  </script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/app/templates/cert_retencion.html
+++ b/app/templates/cert_retencion.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+{% block content %}
+  <div id="table-container" class="flex-grow-1 overflow-auto">
+    <div id="table-controls" class="d-flex align-items-center justify-content-center my-4">
+      <button id="add-certificate" class="btn action-btn d-inline-flex align-items-center"><i class="bi bi-file-earmark-plus me-1"></i>+ Certificado</button>
+      <input id="search-box" class="form-control" type="search" placeholder="Buscar">
+      <a href="/billing.html" class="btn action-btn d-inline-flex align-items-center" id="back-to-billing"><i class="bi bi-arrow-left me-1"></i>Volver</a>
+    </div>
+    <div id="cert-table-wrapper" class="table-responsive">
+      <table id="cert-table" class="table table-striped table-sm mb-0 w-100">
+        <colgroup>
+          <col class="col-number">
+          <col class="col-date">
+          <col class="col-ref">
+          <col class="col-concept">
+          <col class="col-amount">
+          {% if user and user.is_admin %}
+          <col class="col-actions">
+          {% endif %}
+        </colgroup>
+        <thead class="text-center">
+          <tr>
+            <th>Número</th>
+            <th>Fecha</th>
+            <th>Factura referida</th>
+            <th>Concepto</th>
+            <th>Monto</th>
+            {% if user and user.is_admin %}
+            <th>Acciones</th>
+            {% endif %}
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+  <div class="modal fade" id="certModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form id="cert-form">
+          <div class="modal-header">
+            <h5 class="modal-title" id="cert-form-title">Nuevo certificado</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="row g-3 mb-3">
+              <div class="col-sm-6">
+                <label class="form-label w-100">Fecha
+                  <input type="date" name="date" class="form-control" required>
+                </label>
+              </div>
+              <div class="col-sm-6">
+                <label class="form-label w-100">Número
+                  <input type="text" name="number" class="form-control" required>
+                </label>
+              </div>
+            </div>
+            <div class="mb-3">
+              <label class="form-label w-100">Factura referida
+                <input type="text" name="invoice_reference" class="form-control" required>
+              </label>
+            </div>
+            <div class="mb-3">
+              <label class="form-label w-100">Concepto
+                <input type="text" name="concept" class="form-control" required>
+              </label>
+            </div>
+            <div class="row g-3 justify-content-end mb-3">
+              <div class="col-sm-6 ms-auto">
+                <label class="form-label w-100">Monto
+                  <input type="text" inputmode="decimal" name="amount" class="form-control text-end" required>
+                </label>
+              </div>
+            </div>
+            <div id="cert-alert" class="alert d-none" role="alert"></div>
+          </div>
+          <div class="modal-footer">
+            <button type="submit" class="btn btn-primary">Guardar</button>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+{% block scripts %}
+  <script>
+    window.certCurrency = "{{ billing_currency.value if billing_currency else 'ARS' }}";
+  </script>
+  <script type="module" src="/static/js/cert_retencion.js?v=1"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a RetentionCertificate table, schemas and API endpoints for CRUD operations
- expose a "Más Documentos" dropdown in billing views and add the certificates page
- implement the certificates UI with live search and modals to create, edit and delete items

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cb19b93a0483328b47105a19ddcdf1