### PR TITLE
Use Bootstrap modals for user messages

### DIFF
--- a/app/static/js/billing.js
+++ b/app/static/js/billing.js
@@ -302,7 +302,9 @@ async function loadMore() {
 
 function openModal(type) {
   if (!billingAccount) {
-    alert('Se requiere una cuenta de facturación');
+    showAlertModal('Se requiere una cuenta de facturación', {
+      title: 'Atención'
+    });
     return;
   }
   form.reset();

--- a/app/static/js/cert_retencion.js
+++ b/app/static/js/cert_retencion.js
@@ -370,12 +370,18 @@ form.addEventListener('submit', async event => {
 });
 
 async function confirmDelete(cert) {
-  if (!confirm('¿Eliminar certificado?')) return;
+  const confirmed = await showConfirmModal('¿Eliminar certificado?', {
+    confirmText: 'Eliminar'
+  });
+  if (!confirmed) return;
   showOverlay();
   try {
     const result = await deleteRetentionCertificate(cert.id);
     if (!result.ok) {
-      alert(result.error || 'Error al eliminar');
+      showAlertModal(result.error || 'Error al eliminar', {
+        title: 'Error',
+        confirmClass: 'btn-danger'
+      });
       return;
     }
     certificates = certificates.filter(item => item.id !== cert.id);

--- a/app/static/js/config.js
+++ b/app/static/js/config.js
@@ -131,7 +131,10 @@ form.addEventListener('submit', async e => {
   if (payload.is_billing) {
     const existing = accounts.find(a => a.is_billing && a.id !== parseInt(idField.value || '0', 10));
     if (existing) {
-      const ok = confirm(`La cuenta "${existing.name}" ya es de facturación. ¿Reemplazarla?`);
+      const ok = await showConfirmModal(`La cuenta "${existing.name}" ya es de facturación. ¿Reemplazarla?`, {
+        confirmText: 'Reemplazar',
+        confirmClass: 'btn-warning'
+      });
       if (!ok) return;
       replaceBilling = true;
     }
@@ -200,7 +203,10 @@ confirmBtn.addEventListener('click', async () => {
     tbody.innerHTML = '';
     await loadAccounts();
   } else {
-    alert(result.error || 'Error al eliminar');
+    showAlertModal(result.error || 'Error al eliminar', {
+      title: 'Error',
+      confirmClass: 'btn-danger'
+    });
   }
   accountToDelete = null;
 });
@@ -273,7 +279,10 @@ freqConfirmBtn.addEventListener('click', async () => {
     freqTbody.innerHTML = '';
     await loadFrequents();
   } else {
-    alert(result.error || 'Error al eliminar');
+    showAlertModal(result.error || 'Error al eliminar', {
+      title: 'Error',
+      confirmClass: 'btn-danger'
+    });
   }
   freqToDelete = null;
 });
@@ -343,7 +352,10 @@ taxConfirmBtn.addEventListener('click', async () => {
     taxTbody.innerHTML = '';
     await loadRetainedTaxTypes();
   } else {
-    alert(result.error || 'Error al eliminar');
+    showAlertModal(result.error || 'Error al eliminar', {
+      title: 'Error',
+      confirmClass: 'btn-danger'
+    });
   }
   taxToDelete = null;
 });

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -127,7 +127,10 @@ function openEditModal(tx) {
 }
 
 async function confirmDelete(tx) {
-  if (!confirm('¿Eliminar movimiento?')) return;
+  const confirmed = await showConfirmModal('¿Eliminar movimiento?', {
+    confirmText: 'Eliminar'
+  });
+  if (!confirmed) return;
   showOverlay();
   const result = await deleteTransaction(tx.id);
   hideOverlay();
@@ -136,7 +139,10 @@ async function confirmDelete(tx) {
     offset = 0;
     await loadMore();
   } else {
-    alert(result.error || 'Error al eliminar');
+    showAlertModal(result.error || 'Error al eliminar', {
+      title: 'Error',
+      confirmClass: 'btn-danger'
+    });
   }
 }
 
@@ -293,10 +299,15 @@ if (billingSyncButton) {
       offset = 0;
       await loadMore();
       if (result.data?.message) {
-        alert(result.data.message);
+        showAlertModal(result.data.message, {
+          title: 'Sincronización completada'
+        });
       }
     } else if (result.error) {
-      alert(result.error);
+      showAlertModal(result.error, {
+        title: 'Error',
+        confirmClass: 'btn-danger'
+      });
     }
   });
 }

--- a/app/static/js/modal.js
+++ b/app/static/js/modal.js
@@ -1,0 +1,121 @@
+(() => {
+  const modalElement = document.getElementById('app-message-modal');
+  if (!modalElement) return;
+
+  const modal = new bootstrap.Modal(modalElement);
+  const titleElement = modalElement.querySelector('.modal-title');
+  const bodyElement = modalElement.querySelector('.modal-body');
+  const primaryButton = modalElement.querySelector('[data-modal-primary]');
+  const secondaryButton = modalElement.querySelector('[data-modal-secondary]');
+
+  function openModal({
+    title = 'Aviso',
+    message = '',
+    confirmText = 'Aceptar',
+    cancelText = 'Cancelar',
+    showCancel = false,
+    confirmClass = 'btn-primary',
+    defaultValue = true
+  }) {
+    titleElement.textContent = title;
+    bodyElement.textContent = message;
+    primaryButton.textContent = confirmText;
+    primaryButton.classList.remove('btn-primary', 'btn-danger', 'btn-success', 'btn-warning');
+    primaryButton.classList.add(confirmClass);
+
+    if (showCancel) {
+      secondaryButton.textContent = cancelText;
+      secondaryButton.classList.remove('d-none');
+    } else {
+      secondaryButton.classList.add('d-none');
+    }
+
+    return new Promise(resolve => {
+      let resolved = false;
+
+      const finish = value => {
+        if (resolved) return;
+        resolved = true;
+        modalElement.removeEventListener('hidden.bs.modal', onHidden);
+        primaryButton.removeEventListener('click', onConfirm);
+        secondaryButton.removeEventListener('click', onCancelClick);
+        resolve(value);
+      };
+
+      const onConfirm = () => {
+        finish(true);
+        modal.hide();
+      };
+
+      const onCancelClick = () => {
+        finish(false);
+        modal.hide();
+      };
+
+      const onHidden = () => {
+        finish(defaultValue);
+      };
+
+      primaryButton.addEventListener('click', onConfirm);
+      secondaryButton.addEventListener('click', onCancelClick);
+      modalElement.addEventListener('hidden.bs.modal', onHidden);
+
+      modal.show();
+    });
+  }
+
+  window.showAlertModal = function (message, options = {}) {
+    const {
+      title = 'Aviso',
+      confirmText = 'Aceptar',
+      confirmClass = 'btn-primary',
+      defaultValue = true
+    } = options;
+    return openModal({
+      title,
+      message,
+      confirmText,
+      confirmClass,
+      showCancel: false,
+      defaultValue
+    });
+  };
+
+  window.showConfirmModal = function (message, options = {}) {
+    const {
+      title = 'Confirmación',
+      confirmText = 'Aceptar',
+      cancelText = 'Cancelar',
+      confirmClass = 'btn-danger',
+      defaultValue = false
+    } = options;
+    return openModal({
+      title,
+      message,
+      confirmText,
+      cancelText,
+      confirmClass,
+      showCancel: true,
+      defaultValue
+    });
+  };
+
+  document.addEventListener('submit', event => {
+    const form = event.target;
+    if (!(form instanceof HTMLFormElement)) return;
+    const message = form.dataset.confirm;
+    if (!message) return;
+
+    event.preventDefault();
+    showConfirmModal(message, {
+      title: form.dataset.confirmTitle,
+      confirmText: form.dataset.confirmConfirmText || 'Aceptar',
+      cancelText: form.dataset.confirmCancelText || 'Cancelar',
+      confirmClass: form.dataset.confirmClass || 'btn-danger'
+    }).then(confirmed => {
+      if (confirmed) {
+        form.submit();
+      }
+    });
+  });
+})();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -64,6 +64,21 @@
     </div>
   </div>
   {% block content %}{% endblock %}
+  <div class="modal fade" id="app-message-modal" tabindex="-1" aria-labelledby="app-message-modal-label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="app-message-modal-label">Aviso</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+        <div class="modal-body" id="app-message-modal-body"></div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary d-none" data-modal-secondary>Cancelar</button>
+          <button type="button" class="btn btn-primary" data-modal-primary>Aceptar</button>
+        </div>
+      </div>
+    </div>
+  </div>
   <div id="overlay" class="d-none">
     <div class="spinner-border text-primary" role="status"></div>
   </div>
@@ -71,6 +86,7 @@
   <script>
     window.isAdmin = {{ 1 if user and user.is_admin else 0 }};
   </script>
+  <script src="/static/js/modal.js?v=1"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/app/templates/invoice_detail.html
+++ b/app/templates/invoice_detail.html
@@ -39,7 +39,7 @@
   <button id="edit-btn" class="btn btn-primary me-2">
     <i class="bi bi-pencil"></i> Editar
   </button>
-  <form action="/invoice/{{ invoice.id }}/delete" method="post" class="d-inline" onsubmit="return confirm('¿Eliminar factura?');">
+  <form action="/invoice/{{ invoice.id }}/delete" method="post" class="d-inline" data-confirm="¿Eliminar factura?" data-confirm-confirm-text="Eliminar">
     <button class="btn btn-danger"><i class="bi bi-trash"></i> Eliminar</button>
   </form>
 </div>

--- a/app/templates/users.html
+++ b/app/templates/users.html
@@ -20,7 +20,7 @@
           <form method='post' action='/users/{{ u.id }}/approve' class='d-inline'>
             <button class='btn btn-sm btn-success' title='Aprobar'><i class='bi bi-check'></i></button>
           </form>
-          <form method='post' action='/users/{{ u.id }}/delete' class='d-inline' onsubmit='return confirm("¿Eliminar usuario?");'>
+          <form method='post' action='/users/{{ u.id }}/delete' class='d-inline' data-confirm='¿Eliminar usuario?' data-confirm-confirm-text='Eliminar'>
             <button class='btn btn-sm btn-danger' title='Eliminar'><i class='bi bi-trash'></i></button>
           </form>
         </td>
@@ -52,7 +52,7 @@
           </form>
           {% endif %}
           {% if user.is_admin or u.id == user.id %}
-          <form method='post' action='/users/{{ u.id }}/delete' class='d-inline' onsubmit='return confirm("¿Eliminar usuario?");'>
+          <form method='post' action='/users/{{ u.id }}/delete' class='d-inline' data-confirm='¿Eliminar usuario?' data-confirm-confirm-text='Eliminar'>
             <button class='btn btn-sm btn-danger' title='Eliminar'><i class='bi bi-trash'></i></button>
           </form>
           {% endif %}


### PR DESCRIPTION
## Summary
- add a shared Bootstrap modal and helper script to show alert and confirm dialogs
- replace native alert/confirm usage in transaction, billing, retention certificate, and configuration flows with the new modal helpers
- update invoice and user deletion forms to trigger the shared confirmation modal

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3fa62bd1483328eb17576eb23ecec