### PR TITLE
Show billing movement notifications on sync button

### DIFF
--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -30,7 +30,7 @@ INBOUND_RATE_LIMIT = 60
 INBOUND_RATE_WINDOW_SECONDS = 60
 RETENTION_DAYS = 90
 RETENTION_INTERVAL_SECONDS = 24 * 60 * 60
-ALLOWED_SOURCE_APPS = {"app-a", "app-b"}
+ALLOWED_SOURCE_APPS = {"app-a", "app-b", "movimientos-ta", "inkwell", "inkwell-ta"}
 
 
 def require_shared_secret() -> str:
@@ -41,9 +41,10 @@ def require_shared_secret() -> str:
 
 
 def _require_source_app() -> str:
-    source = os.getenv("NOTIF_SOURCE_APP", "app-a")
+    source = os.getenv("NOTIF_SOURCE_APP", "inkwell")
     if source not in ALLOWED_SOURCE_APPS:
-        raise RuntimeError("NOTIF_SOURCE_APP must be one of app-a|app-b")
+        allowed = "|".join(sorted(ALLOWED_SOURCE_APPS))
+        raise RuntimeError(f"NOTIF_SOURCE_APP must be one of {allowed}")
     return source
 
 

--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -2,6 +2,39 @@ body {
   font-family: sans-serif;
 }
 
+#billing-sync-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.billing-sync-button-label {
+  display: inline-flex;
+  align-items: center;
+}
+
+.notification-badge {
+  position: absolute;
+  top: -0.35rem;
+  right: -0.35rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+  background-color: #dc3545;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 1;
+  box-shadow: 0 0.25rem 0.5rem rgba(220, 53, 69, 0.35);
+}
+
 .tax-line {
   display: grid;
   grid-template-columns: max-content minmax(4.75rem, 5.5rem) minmax(0, 1fr);

--- a/app/static/js/accounts.js
+++ b/app/static/js/accounts.js
@@ -1,4 +1,4 @@
-import { fetchAccountBalances, fetchAccountSummary } from './api.js?v=2';
+import { fetchAccountBalances, fetchAccountSummary } from './api.js?v=3';
 import { showOverlay, hideOverlay, formatCurrency } from './ui.js?v=2';
 import { CURRENCY_SYMBOLS } from './constants.js';
 

--- a/app/static/js/billing.js
+++ b/app/static/js/billing.js
@@ -1,4 +1,4 @@
-import { fetchAccounts, fetchInvoices, createInvoice } from './api.js?v=2';
+import { fetchAccounts, fetchInvoices, createInvoice } from './api.js?v=3';
 import { renderInvoice, showOverlay, hideOverlay } from './ui.js?v=2';
 import { sanitizeDecimalInput, parseDecimal, formatCurrency } from './money.js?v=1';
 

--- a/app/static/js/cert_retencion.js
+++ b/app/static/js/cert_retencion.js
@@ -4,7 +4,7 @@ import {
   updateRetentionCertificate,
   deleteRetentionCertificate,
   fetchRetainedTaxTypes
-} from './api.js?v=2';
+} from './api.js?v=3';
 import { formatCurrency, showOverlay, hideOverlay } from './ui.js?v=2';
 import { sanitizeDecimalInput, parseDecimal } from './money.js?v=1';
 import { CURRENCY_SYMBOLS } from './constants.js';

--- a/app/static/js/config.js
+++ b/app/static/js/config.js
@@ -11,7 +11,7 @@ import {
   createRetainedTaxType,
   updateRetainedTaxType,
   deleteRetainedTaxType
-} from './api.js?v=2';
+} from './api.js?v=3';
 import {
   renderAccount,
   renderFrequent,

--- a/app/static/js/invoice_edit.js
+++ b/app/static/js/invoice_edit.js
@@ -1,4 +1,4 @@
-import { updateInvoice } from './api.js?v=2';
+import { updateInvoice } from './api.js?v=3';
 import { showOverlay, hideOverlay } from './ui.js?v=2';
 import { sanitizeDecimalInput, parseDecimal, formatCurrency } from './money.js?v=1';
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -32,7 +32,8 @@
       <button id="billing-sync-button" type="button"
         class="btn btn-sm ms-3"
         style="--bs-btn-color: {{ billing_account.color }}; --bs-btn-border-color: {{ billing_account.color }}; --bs-btn-hover-color: {{ billing_account.color }}; --bs-btn-hover-border-color: {{ billing_account.color }}; --bs-btn-hover-bg: rgba(255,255,255,0.15); border-color: {{ billing_account.color }}; color: {{ billing_account.color }}; background-color: transparent;">
-        Traer movimientos para: {{ billing_account.name }}
+        <span id="billing-sync-button-label" class="billing-sync-button-label">Traer movimientos para: {{ billing_account.name }}</span>
+        <span id="billing-notification-badge" class="notification-badge d-none" aria-hidden="true"></span>
       </button>
       {% endif %}
     </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -74,5 +74,5 @@
 {% endblock %}
 {% block scripts %}
   <script>window.isAdmin = {{ 1 if user and user.is_admin else 0 }};</script>
-  <script type="module" src="/static/js/main.js?v=2"></script>
+  <script type="module" src="/static/js/main.js?v=3"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow the notifications endpoint to filter unread counts and accept the new Inkwell source app
- add notification API helpers and UI logic to display billing movement badges and acknowledge them after syncing
- style the billing sync button with a badge and cover the filtered count with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d423312afc8332ae6c4faea60f61ff