### PR TITLE
Improve billing sync button prominence

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -6,18 +6,25 @@ body {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.4rem;
+  padding: 0.65rem 1.25rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.1;
+  border-width: 2px;
+  border-radius: 0.75rem;
 }
 
 .billing-sync-button-label {
   display: inline-flex;
   align-items: center;
+  white-space: nowrap;
 }
 
 .notification-badge {
   position: absolute;
-  top: -0.35rem;
-  right: -0.35rem;
+  top: -0.45rem;
+  right: -0.45rem;
   min-width: 1.5rem;
   height: 1.5rem;
   padding: 0 0.4rem;
@@ -33,6 +40,23 @@ body {
   pointer-events: none;
   z-index: 1;
   box-shadow: 0 0.25rem 0.5rem rgba(220, 53, 69, 0.35);
+}
+
+@media (max-width: 576px) {
+  #billing-sync-button {
+    font-size: 0.95rem;
+    padding: 0.6rem 1rem;
+  }
+
+  .billing-sync-button-label {
+    white-space: normal;
+    text-align: left;
+  }
+
+  .notification-badge {
+    top: -0.4rem;
+    right: -0.4rem;
+  }
 }
 
 .tax-line {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -30,7 +30,7 @@
       {% endif %}
       {% if billing_account and show_billing_sync_button %}
       <button id="billing-sync-button" type="button"
-        class="btn btn-sm ms-3"
+        class="btn ms-3"
         style="--bs-btn-color: {{ billing_account.color }}; --bs-btn-border-color: {{ billing_account.color }}; --bs-btn-hover-color: {{ billing_account.color }}; --bs-btn-hover-border-color: {{ billing_account.color }}; --bs-btn-hover-bg: rgba(255,255,255,0.15); border-color: {{ billing_account.color }}; color: {{ billing_account.color }}; background-color: transparent;">
         <span id="billing-sync-button-label" class="billing-sync-button-label">Traer movimientos para: {{ billing_account.name }}</span>
         <span id="billing-notification-badge" class="notification-badge d-none" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
- enlarge the billing sync button on the movimientos header and remove the small-button styling
- refine layout styles to increase font size, padding, border thickness, and corner radius
- keep the notification badge aligned on the updated button and adjust responsive behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d43889155883329f4f2575c75fca02