### PR TITLE
Use new notifications shared secret env var

### DIFF
--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -33,10 +33,13 @@ RETENTION_INTERVAL_SECONDS = 24 * 60 * 60
 ALLOWED_SOURCE_APPS = {"app-a", "app-b", "movimientos-ta", "inkwell", "inkwell-ta"}
 
 
+NOTIFICATIONS_SECRET_ENV = "SECRETO_NOTIFICACIONES_IW_TA"
+
+
 def require_shared_secret() -> str:
-    secret = os.getenv("NOTIF_SHARED_SECRET")
+    secret = os.getenv(NOTIFICATIONS_SECRET_ENV)
     if not secret:
-        raise RuntimeError("NOTIF_SHARED_SECRET is not configured")
+        raise RuntimeError(f"{NOTIFICATIONS_SECRET_ENV} is not configured")
     return secret
 
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -19,7 +19,7 @@ if str(APP_DIR) not in sys.path:
 
 os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
 os.environ.setdefault("DB_SCHEMA", "")
-os.environ.setdefault("NOTIF_SHARED_SECRET", "test-secret")
+os.environ.setdefault("SECRETO_NOTIFICACIONES_IW_TA", "test-secret")
 os.environ.setdefault("NOTIF_SOURCE_APP", "app-a")
 os.environ.setdefault("PEER_BASE_URL", "https://peer.example.com")
 


### PR DESCRIPTION
## Summary
- load the shared secret for notifications from the SECRETO_NOTIFICACIONES_IW_TA environment variable
- update the notification tests to seed the new secret name

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d44c01880c8332a98995fd3da7d4d6