### PR TITLE
Fix retained tax type relationship for certificates

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -108,7 +108,9 @@ class RetainedTaxType(Base):
         DateTime(timezone=True), server_default=func.now()
     )
 
-    certificates = relationship("RetentionCertificate", back_populates="tax_type")
+    certificates = relationship(
+        "RetentionCertificate", back_populates="retained_tax_type"
+    )
 
 
 class RetentionCertificate(Base):
@@ -136,7 +138,9 @@ class RetentionCertificate(Base):
         DateTime(timezone=True), server_default=func.now()
     )
 
-    tax_type = relationship("RetainedTaxType", back_populates="certificates")
+    retained_tax_type = relationship(
+        "RetainedTaxType", back_populates="certificates"
+    )
 
 
 class FrequentTransaction(Base):

--- a/app/routes/certificates.py
+++ b/app/routes/certificates.py
@@ -41,7 +41,7 @@ def create_certificate(
     db.add(cert)
     db.commit()
     db.refresh(cert)
-    cert.tax_type = tax_type
+    cert.retained_tax_type = tax_type
     return cert
 
 
@@ -51,7 +51,7 @@ def list_certificates(
 ):
     stmt = (
         select(RetentionCertificate)
-        .options(selectinload(RetentionCertificate.tax_type))
+        .options(selectinload(RetentionCertificate.retained_tax_type))
         .order_by(RetentionCertificate.date.desc(), RetentionCertificate.id.desc())
         .limit(limit)
         .offset(offset)
@@ -92,7 +92,7 @@ def update_certificate(
     db.add(cert)
     db.commit()
     db.refresh(cert)
-    cert.tax_type = tax_type
+    cert.retained_tax_type = tax_type
     return cert
 
 


### PR DESCRIPTION
## Summary
- rename the retention certificate ORM relationship to `retained_tax_type` so FastAPI responses include the tax data
- update the certificates routes to populate and eager load the renamed relationship

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d45faae3e8833284b39373f42d1bd6