### PR TITLE
Adjust retention certificate search layout

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -409,16 +409,45 @@ a[data-bs-toggle="collapse"][aria-expanded="true"] .menu-chevron {
 }
 
 #table-controls {
-  gap: 8rem;
+  gap: 3rem;
   flex-wrap: wrap;
 }
 
-#search-box {
+.table-search-group {
+  position: relative;
   width: 50rem;
   max-width: 100%;
+}
+
+.table-search-group .form-control {
+  width: 100%;
   font-size: calc(1.1rem + 2pt);
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+  margin: 0;
+  padding-right: 7.5rem;
+}
+
+.table-search-group .table-filter-btn {
+  position: absolute;
+  top: 50%;
+  right: 0.75rem;
+  transform: translateY(-50%);
+  height: calc(1.5em + 0.75rem + 2px);
+  padding-inline: 1.25rem;
+  border-radius: 0.5rem;
+  border-color: #ced4da;
+  background-color: #f8f9fa;
+  color: #495057;
+  box-shadow: none;
+}
+
+.table-search-group .table-filter-btn:hover,
+.table-search-group .table-filter-btn:focus {
+  background-color: #e9ecef;
+  color: #212529;
+}
+
+.table-search-group .table-filter-btn:focus {
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
 }
 
 #add-expense {
@@ -534,10 +563,13 @@ a[data-bs-toggle="collapse"][aria-expanded="true"] .menu-chevron {
     right: 1rem;
   }
   #table-controls {
-    gap: 1rem;
+    gap: 1.5rem;
   }
-  #search-box {
+  .table-search-group {
     width: 100%;
+  }
+  .table-search-group .form-control {
+    padding-right: 6.5rem;
   }
   #tx-table .col-date,
   #tx-table .col-desc,

--- a/app/static/js/cert_retencion.js
+++ b/app/static/js/cert_retencion.js
@@ -31,6 +31,7 @@ const isAdmin = Boolean(window.isAdmin);
 const columnCount = table.querySelectorAll('thead th').length;
 const currencyCode = window.certCurrency || 'ARS';
 const currencySymbol = CURRENCY_SYMBOLS[currencyCode] || '';
+const totalValueEl = document.getElementById('cert-total-value');
 
 let certificates = [];
 let retainedTaxTypes = [];
@@ -248,6 +249,11 @@ function matchesFilters(cert) {
   return true;
 }
 
+function updateTotalDisplay(total) {
+  if (!totalValueEl) return;
+  totalValueEl.textContent = `${currencySymbol} ${formatCurrency(total)}`;
+}
+
 function renderCertificates() {
   const query = searchBox.value.trim().toLowerCase();
   const filtered = certificates.filter(cert => {
@@ -271,6 +277,8 @@ function renderCertificates() {
   });
   clearActionRow();
   tbody.innerHTML = '';
+  let totalAmount = 0;
+
   filtered.forEach(cert => {
     const tr = document.createElement('tr');
     tr.dataset.id = cert.id;
@@ -293,7 +301,9 @@ function renderCertificates() {
     const amountTd = document.createElement('td');
     amountTd.className = 'text-end';
     const amountValue = Number.isFinite(cert.amount) ? cert.amount : 0;
-    amountTd.textContent = `${currencySymbol} ${formatCurrency(Math.abs(amountValue))}`;
+    const displayAmount = Math.abs(amountValue);
+    amountTd.textContent = `${currencySymbol} ${formatCurrency(displayAmount)}`;
+    totalAmount += displayAmount;
 
     tr.append(numberTd, dateTd, refTd, taxTd, amountTd);
     if (isAdmin) {
@@ -303,6 +313,8 @@ function renderCertificates() {
 
     tbody.appendChild(tr);
   });
+
+  updateTotalDisplay(totalAmount);
 }
 
 function setDateLimits() {
@@ -559,4 +571,5 @@ if (clearFiltersBtn) {
 }
 
 updateTaxTypeAvailability();
+updateTotalDisplay(0);
 loadData();

--- a/app/templates/cert_retencion.html
+++ b/app/templates/cert_retencion.html
@@ -1,10 +1,16 @@
 {% extends "base.html" %}
 {% block content %}
   <div id="table-container" class="flex-grow-1 overflow-auto">
-    <div id="table-controls" class="d-flex align-items-center justify-content-center my-4">
+    <div id="table-controls" class="d-flex align-items-center justify-content-center my-4 flex-wrap gap-3">
       <button id="add-certificate" class="btn btn-outline-primary action-btn d-inline-flex align-items-center"><i class="bi bi-file-earmark-plus me-2"></i>Certificado</button>
-      <input id="search-box" class="form-control" type="search" placeholder="Buscar">
-      <button type="button" class="btn btn-outline-secondary action-btn d-inline-flex align-items-center" id="filter-button"><i class="bi bi-funnel me-2"></i>Filtros</button>
+      <div class="input-group table-search-group flex-grow-1 flex-md-grow-0">
+        <input id="search-box" class="form-control" type="search" placeholder="Buscar">
+        <button type="button" class="btn btn-outline-secondary table-filter-btn d-inline-flex align-items-center" id="filter-button"><i class="bi bi-funnel me-2"></i>Filtros</button>
+      </div>
+      <div id="cert-total" class="d-flex align-items-center ms-md-3 ms-lg-4 fw-semibold text-nowrap">
+        <span class="me-2">TOTAL:</span>
+        <span id="cert-total-value">0</span>
+      </div>
     </div>
     <div id="cert-table-wrapper" class="table-responsive">
       <table id="cert-table" class="table table-striped table-sm mb-0 w-100">


### PR DESCRIPTION
## Summary
- keep the retention certificate filter button inside the search input footprint so the control layout stays aligned
- tweak the certificates total badge spacing to sit neatly alongside the search box across screen sizes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d56168e1f88332925b2854aa472451