### PR TITLE
Add unified search layout and filters for movements and billing

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -434,20 +434,20 @@ a[data-bs-toggle="collapse"][aria-expanded="true"] .menu-chevron {
   height: calc(1.5em + 0.75rem + 2px);
   padding-inline: 1.25rem;
   border-radius: 0.5rem;
-  border-color: #ced4da;
-  background-color: #f8f9fa;
-  color: #495057;
+  border-color: #0d6efd;
+  background-color: #fff;
+  color: #0d6efd;
   box-shadow: none;
 }
 
 .table-search-group .table-filter-btn:hover,
 .table-search-group .table-filter-btn:focus {
-  background-color: #e9ecef;
-  color: #212529;
+  background-color: #e7f1ff;
+  color: #0a58ca;
 }
 
 .table-search-group .table-filter-btn:focus {
-  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.35);
 }
 
 #add-expense {

--- a/app/templates/billing.html
+++ b/app/templates/billing.html
@@ -3,7 +3,10 @@
   <div id="table-container" class="flex-grow-1 overflow-auto">
     <div id="table-controls" class="d-flex align-items-center justify-content-center my-4">
       <button id="add-sale" class="btn action-btn d-inline-flex align-items-center"><i class="bi bi-file-earmark-arrow-up me-1"></i>Venta</button>
-      <input id="search-box" class="form-control" type="search" placeholder="Buscar">
+      <div class="input-group table-search-group flex-grow-1 flex-md-grow-0">
+        <input id="search-box" class="form-control" type="search" placeholder="Buscar">
+        <button type="button" class="btn btn-outline-primary table-filter-btn d-inline-flex align-items-center" id="inv-filter-button"><i class="bi bi-funnel me-2"></i>Filtros</button>
+      </div>
       <button id="add-purchase" class="btn action-btn d-inline-flex align-items-center"><i class="bi bi-file-earmark-arrow-down me-1"></i>Compra</button>
     </div>
     <div id="inv-table-wrapper" class="table-responsive">
@@ -26,6 +29,46 @@
         </thead>
         <tbody></tbody>
       </table>
+    </div>
+  </div>
+  <div class="modal fade" id="invFilterModal" tabindex="-1" aria-labelledby="inv-filter-title">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form id="inv-filter-form">
+          <div class="modal-header">
+            <h5 class="modal-title" id="inv-filter-title">Filtros</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="row g-3 mb-3">
+              <div class="col-sm-6">
+                <label class="form-label w-100">Fecha inicio
+                  <input type="date" name="start_date" class="form-control">
+                </label>
+              </div>
+              <div class="col-sm-6">
+                <label class="form-label w-100">Fecha fin
+                  <input type="date" name="end_date" class="form-control">
+                </label>
+              </div>
+            </div>
+            <div class="mb-3">
+              <label class="form-label w-100">Tipo
+                <select name="filter_type" class="form-select">
+                  <option value="">Todos</option>
+                  <option value="sale">Venta</option>
+                  <option value="purchase">Compra</option>
+                </select>
+              </label>
+            </div>
+            <div id="inv-filter-alert" class="alert alert-danger d-none" role="alert"></div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" id="inv-clear-filters">Limpiar</button>
+            <button type="submit" class="btn btn-primary">Aplicar</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
   <div class="modal fade" id="invModal" tabindex="-1">

--- a/app/templates/cert_retencion.html
+++ b/app/templates/cert_retencion.html
@@ -5,7 +5,7 @@
       <button id="add-certificate" class="btn btn-outline-primary action-btn d-inline-flex align-items-center"><i class="bi bi-file-earmark-plus me-2"></i>Certificado</button>
       <div class="input-group table-search-group flex-grow-1 flex-md-grow-0">
         <input id="search-box" class="form-control" type="search" placeholder="Buscar">
-        <button type="button" class="btn btn-outline-secondary table-filter-btn d-inline-flex align-items-center" id="filter-button"><i class="bi bi-funnel me-2"></i>Filtros</button>
+        <button type="button" class="btn btn-outline-primary table-filter-btn d-inline-flex align-items-center" id="filter-button"><i class="bi bi-funnel me-2"></i>Filtros</button>
       </div>
       <div id="cert-total" class="d-flex align-items-center ms-md-3 ms-lg-4 fw-semibold text-nowrap">
         <span class="me-2">TOTAL:</span>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,7 +3,10 @@
   <div id="table-container" class="flex-grow-1 overflow-auto">
     <div id="table-controls" class="d-flex align-items-center justify-content-center my-4">
       <button id="add-income" class="btn border border-primary text-primary action-btn d-inline-flex align-items-center"><i class="bi bi-box-arrow-in-right me-1"></i>Ingreso</button>
-      <input id="search-box" class="form-control" type="search" placeholder="Buscar">
+      <div class="input-group table-search-group flex-grow-1 flex-md-grow-0">
+        <input id="search-box" class="form-control" type="search" placeholder="Buscar">
+        <button type="button" class="btn btn-outline-primary table-filter-btn d-inline-flex align-items-center" id="tx-filter-button"><i class="bi bi-funnel me-2"></i>Filtros</button>
+      </div>
       <button id="add-expense" class="btn border border-warning action-btn d-inline-flex align-items-center"><i class="bi bi-box-arrow-right me-1"></i>Egreso</button>
     </div>
     <div id="tx-table-wrapper" class="table-responsive">
@@ -24,6 +27,44 @@
         </thead>
         <tbody></tbody>
       </table>
+    </div>
+  </div>
+  <div class="modal fade" id="txFilterModal" tabindex="-1" aria-labelledby="tx-filter-title">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form id="tx-filter-form">
+          <div class="modal-header">
+            <h5 class="modal-title" id="tx-filter-title">Filtros</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="row g-3 mb-3">
+              <div class="col-sm-6">
+                <label class="form-label w-100">Fecha inicio
+                  <input type="date" name="start_date" class="form-control">
+                </label>
+              </div>
+              <div class="col-sm-6">
+                <label class="form-label w-100">Fecha fin
+                  <input type="date" name="end_date" class="form-control">
+                </label>
+              </div>
+            </div>
+            <div class="mb-3">
+              <label class="form-label w-100">Cuenta
+                <select name="filter_account_id" class="form-select">
+                  <option value="">Todas</option>
+                </select>
+              </label>
+            </div>
+            <div id="tx-filter-alert" class="alert alert-danger d-none" role="alert"></div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" id="tx-clear-filters">Limpiar</button>
+            <button type="submit" class="btn btn-primary">Aplicar</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
   <div class="modal fade" id="txModal" tabindex="-1">


### PR DESCRIPTION
## Summary
- center the search bar between action buttons in Movimientos and Facturación and add dedicated filter triggers
- add filter modals for movimientos (fecha inicio/fin y cuenta) and facturación (fecha inicio/fin y tipo)
- update the global filter button outline to use the stronger blue styling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d58227cd5c83329e03091c28b053bb