### PR TITLE
Add billing account details page with retention breakdown

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -108,6 +108,11 @@ class RetentionCertificateOut(RetentionCertificateCreate):
         from_attributes = True
 
 
+class RetentionBreakdown(BaseModel):
+    name: str
+    amount: Decimal
+
+
 class FrequentIn(BaseModel):
     description: str
 
@@ -140,6 +145,10 @@ class AccountSummary(BaseModel):
     iva_sales: Decimal | None = None
     iibb: Decimal | None = None
     percepciones: Decimal | None = None
+    iva_withholdings: Decimal | None = None
+    iibb_withholdings: Decimal | None = None
+    retentions_total: Decimal | None = None
+    other_withholdings: List[RetentionBreakdown] | None = None
 
 
 class UserCreate(BaseModel):

--- a/app/templates/accounts.html
+++ b/app/templates/accounts.html
@@ -21,5 +21,5 @@
   </main>
 {% endblock %}
 {% block scripts %}
-  <script type="module" src="/static/js/accounts.js?v=2"></script>
+  <script type="module" src="/static/js/accounts.js?v=3"></script>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -35,7 +35,7 @@
       <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
     </div>
     <div class="offcanvas-body d-flex flex-column">
-      {% set billing_section_paths = ["/billing.html", "/certificados-retencion.html"] %}
+      {% set billing_section_paths = ["/billing.html", "/certificados-retencion.html", "/billing-account-details.html"] %}
       {% set billing_section_active = request.url.path in billing_section_paths %}
       <ul class="list-unstyled">
         <li class="mb-2"><a href="/" class="text-decoration-none side-menu-link"><i class="bi bi-house me-2"></i>Movimientos</a></li>

--- a/app/templates/billing_account_details.html
+++ b/app/templates/billing_account_details.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% block content %}
+  <main class="container mt-3">
+    <div class="p-3 p-md-4 border rounded bg-white shadow-sm">
+      <h2 class="mb-4">Detalles de facturación</h2>
+      <div class="mb-4">
+        <p class="mb-1 text-muted text-uppercase small">Saldo inicial</p>
+        <p class="h5 mb-0">{{ symbol }} {{ summary.opening_balance|money }}</p>
+      </div>
+      <div class="row g-3">
+        <div class="col-12 col-lg-6">
+          <div class="h-100 border rounded p-3">
+            <h3 class="h6 text-uppercase text-muted mb-3">Suman</h3>
+            {% for item in positive_items %}
+            <div class="d-flex justify-content-between align-items-center py-1">
+              <span>{{ item.label }}</span>
+              <span class="fw-semibold text-success">{{ symbol }} {{ item.value|money }}</span>
+            </div>
+            {% endfor %}
+          </div>
+        </div>
+        <div class="col-12 col-lg-6">
+          <div class="h-100 border rounded p-3">
+            <h3 class="h6 text-uppercase text-muted mb-3">Restan</h3>
+            {% for item in negative_items %}
+            <div class="d-flex justify-content-between align-items-center py-1">
+              <span>{{ item.label }}</span>
+              <span class="fw-semibold text-danger">{{ symbol }} {{ item.value|money }}</span>
+            </div>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+      <hr class="my-4" />
+      <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+        <span class="h5 mb-0">Total disponible</span>
+        <span class="h4 mb-0 text-primary">{{ symbol }} {{ total_available|money }}</span>
+      </div>
+      {% if other_retentions %}
+      <div class="mt-4">
+        <h3 class="h6 text-uppercase text-muted mb-3">Otras retenciones</h3>
+        <div class="row row-cols-1 row-cols-md-2 g-2">
+          {% for retention in other_retentions %}
+          <div class="col">
+            <div class="border rounded p-2 d-flex justify-content-between align-items-center">
+              <span>Retenciones {{ retention.name }}</span>
+              <span class="fw-semibold">{{ symbol }} {{ retention.amount|money }}</span>
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+    </div>
+  </main>
+{% endblock %}


### PR DESCRIPTION
## Summary
- compute retention breakdowns for billing accounts and expose them through account summaries and balances
- add a dedicated billing account details page that highlights totals, retentions, and available balance
- update account detail panel to link to the new page and surface withholding values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5996316ac8332b4c6cf8a9e685847