### PR TITLE
Expose billing export details in /facturacion-info

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -49,7 +49,7 @@ api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 def require_api_key(api_key: str = Depends(api_key_header)) -> None:
     """Validate request API key against the configured billing key."""
 
-    expected = os.getenv("BILLING_API_KEY")
+    expected = os.getenv("SELF_BILLING_API_KEY")
     if not api_key or api_key != expected:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="No autorizado")
 

--- a/app/routes/billing_info.py
+++ b/app/routes/billing_info.py
@@ -1,22 +1,36 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from auth import require_api_key
 from config.db import get_db
-from models import Account
-from schemas import AccountOut
+from models import Account, Invoice, RetentionCertificate
+from schemas import BillingInfoOut
 
 router = APIRouter()
 
 
 @router.get(
     "/facturacion-info",
-    response_model=AccountOut,
+    response_model=BillingInfoOut,
     dependencies=[Depends(require_api_key)],
 )
 def billing_info(db: Session = Depends(get_db)):
     acc = db.scalar(select(Account).where(Account.is_billing == True))
     if not acc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Billing account not found")
-    return acc
+    invoices = list(
+        db.scalars(
+            select(Invoice)
+            .where(Invoice.account_id == acc.id)
+            .order_by(Invoice.date, Invoice.id)
+        )
+    )
+    certificates = list(
+        db.scalars(
+            select(RetentionCertificate)
+            .options(selectinload(RetentionCertificate.retained_tax_type))
+            .order_by(RetentionCertificate.date, RetentionCertificate.id)
+        )
+    )
+    return BillingInfoOut(invoices=invoices, retention_certificates=certificates)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -108,6 +108,11 @@ class RetentionCertificateOut(RetentionCertificateCreate):
         from_attributes = True
 
 
+class BillingInfoOut(BaseModel):
+    invoices: List[InvoiceOut]
+    retention_certificates: List[RetentionCertificateOut]
+
+
 class RetentionBreakdown(BaseModel):
     name: str
     amount: Decimal


### PR DESCRIPTION
## Summary
- switch the billing info API key validation to use the SELF_BILLING_API_KEY environment variable
- expose all billing invoices and retention certificates from `/facturacion-info`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da838ba9048332bd3b05d37d71f5d3