### PR TITLE
Enhance billing notification indicators

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -34,15 +34,23 @@ a[data-bs-toggle="collapse"][aria-expanded="true"] .menu-chevron {
   white-space: nowrap;
 }
 
-.notification-badge {
+.notification-badges {
   position: absolute;
   top: -0.45rem;
   right: -0.45rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.notification-badge {
   min-width: 1.5rem;
   height: 1.5rem;
   padding: 0 0.4rem;
   border-radius: 999px;
-  background-color: #dc3545;
   color: #fff;
   font-size: 0.75rem;
   font-weight: 600;
@@ -50,8 +58,22 @@ a[data-bs-toggle="collapse"][aria-expanded="true"] .menu-chevron {
   display: flex;
   align-items: center;
   justify-content: center;
-  pointer-events: none;
-  z-index: 1;
+  white-space: nowrap;
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.25);
+}
+
+.notification-badge[data-type="created"] {
+  background-color: #198754;
+  box-shadow: 0 0.25rem 0.5rem rgba(25, 135, 84, 0.35);
+}
+
+.notification-badge[data-type="updated"] {
+  background-color: #0d6efd;
+  box-shadow: 0 0.25rem 0.5rem rgba(13, 110, 253, 0.35);
+}
+
+.notification-badge[data-type="deleted"] {
+  background-color: #dc3545;
   box-shadow: 0 0.25rem 0.5rem rgba(220, 53, 69, 0.35);
 }
 
@@ -66,7 +88,7 @@ a[data-bs-toggle="collapse"][aria-expanded="true"] .menu-chevron {
     text-align: left;
   }
 
-  .notification-badge {
+  .notification-badges {
     top: -0.4rem;
     right: -0.4rem;
   }

--- a/app/static/js/modal.js
+++ b/app/static/js/modal.js
@@ -11,6 +11,7 @@
   function openModal({
     title = 'Aviso',
     message = '',
+    html = null,
     confirmText = 'Aceptar',
     cancelText = 'Cancelar',
     showCancel = false,
@@ -18,7 +19,23 @@
     defaultValue = true
   }) {
     titleElement.textContent = title;
-    bodyElement.textContent = message;
+    if (html !== null && html !== undefined) {
+      bodyElement.innerHTML = html;
+    } else {
+      const text = message === null || message === undefined ? '' : String(message);
+      if (text.includes('\n')) {
+        bodyElement.textContent = '';
+        const lines = text.split('\n');
+        lines.forEach((line, index) => {
+          bodyElement.appendChild(document.createTextNode(line));
+          if (index < lines.length - 1) {
+            bodyElement.appendChild(document.createElement('br'));
+          }
+        });
+      } else {
+        bodyElement.textContent = text;
+      }
+    }
     primaryButton.textContent = confirmText;
     primaryButton.classList.remove('btn-primary', 'btn-danger', 'btn-success', 'btn-warning');
     primaryButton.classList.add(confirmClass);
@@ -69,11 +86,13 @@
       title = 'Aviso',
       confirmText = 'Aceptar',
       confirmClass = 'btn-primary',
-      defaultValue = true
+      defaultValue = true,
+      html = null
     } = options;
     return openModal({
       title,
       message,
+      html,
       confirmText,
       confirmClass,
       showCancel: false,
@@ -87,11 +106,13 @@
       confirmText = 'Aceptar',
       cancelText = 'Cancelar',
       confirmClass = 'btn-danger',
-      defaultValue = false
+      defaultValue = false,
+      html = null
     } = options;
     return openModal({
       title,
       message,
+      html,
       confirmText,
       cancelText,
       confirmClass,

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,7 +21,11 @@
         class="btn ms-3"
         style="--bs-btn-color: {{ billing_account.color }}; --bs-btn-border-color: {{ billing_account.color }}; --bs-btn-hover-color: {{ billing_account.color }}; --bs-btn-hover-border-color: {{ billing_account.color }}; --bs-btn-hover-bg: rgba(255,255,255,0.15); border-color: {{ billing_account.color }}; color: {{ billing_account.color }}; background-color: transparent;">
         <span id="billing-sync-button-label" class="billing-sync-button-label">Traer movimientos para: {{ billing_account.name }}</span>
-        <span id="billing-notification-badge" class="notification-badge d-none" aria-hidden="true"></span>
+        <span id="billing-notification-badges" class="notification-badges d-none" aria-hidden="true">
+          <span class="notification-badge d-none" data-type="created"></span>
+          <span class="notification-badge d-none" data-type="updated"></span>
+          <span class="notification-badge d-none" data-type="deleted"></span>
+        </span>
       </button>
       {% endif %}
     </div>


### PR DESCRIPTION
## Summary
- replace the billing sync badge with separate created/updated/deleted indicators and style them
- track notification counts by event type, show per-event badges, and surface summaries in the sync flow
- allow alert modals to render HTML or multiline content for notification summaries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc101eab9c8332a36ebe5fb2ac16e7