### PR TITLE
Align billing sync to transaction events contract

### DIFF
--- a/tests/test_billing_sync.py
+++ b/tests/test_billing_sync.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from datetime import date
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 
@@ -38,23 +38,39 @@ class DummyResponse:
 
     def json(self):
         return self._payload
+
+
+def _build_transaction_event(event: str, transaction_id: int, payload: dict | None) -> dict:
+    data = {
+        "id": transaction_id,
+        "event": event,
+        "occurred_at": "2024-01-04T10:00:00Z",
+        "transaction_id": transaction_id,
+    }
+    if payload is not None:
+        data["transaction"] = payload
+    return data
+
+
 def test_sync_billing_transactions_applies_events_and_acknowledges_checkpoint(monkeypatch):
-    os.environ["FACTURACION_RUTA_DATA"] = "https://facturacion.example/api"
+    os.environ["FACTURACION_RUTA_DATA"] = "https://facturacion.example/api/movimientos_cuenta_facturada"
     os.environ["BILLING_API_KEY"] = "secret"
 
     get_calls: list[dict] = []
 
     def fake_get(url, params=None, headers=None, timeout=None):
-        get_calls.append({
-            "url": url,
-            "params": params,
-            "headers": headers,
-            "timeout": timeout,
-        })
+        get_calls.append(
+            {
+                "url": url,
+                "params": params,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
         assert headers == {"X-API-Key": "secret"}
         expected_feed_url = os.environ["FACTURACION_RUTA_DATA"].rstrip("/")
         assert url == expected_feed_url
-        assert params == {"limit": 2, "changes_limit": 2, "changes_since": 850}
+        assert params == {"limit": 3, "changes_limit": 3, "changes_since": 850}
         return DummyResponse(
             200,
             {
@@ -65,34 +81,50 @@ def test_sync_billing_transactions_applies_events_and_acknowledges_checkpoint(mo
                         "amount": "150.50",
                         "description": "Alta",
                         "notes": "Creado",
-                    }
-                ],
-                "transactions_checkpoint_id": 903,
-                "last_confirmed_transaction_id": 850,
-                "has_more_transactions": False,
-                "changes": [
+                    },
                     {
-                        "id": 904,
-                        "movement_id": 600,
-                        "event": "updated",
-                        "payload": {
+                        "id": 600,
+                        "date": "2024-01-02",
+                        "amount": "200.00",
+                        "description": "Actualizada",
+                        "notes": "Modificada",
+                    },
+                ],
+                "transaction_events": [
+                    _build_transaction_event(
+                        "created",
+                        501,
+                        {
+                            "id": 501,
+                            "date": "2024-01-03",
+                            "amount": "150.50",
+                            "description": "Alta",
+                            "notes": "Creado",
+                        },
+                    ),
+                    _build_transaction_event(
+                        "updated",
+                        600,
+                        {
                             "id": 600,
                             "date": "2024-01-02",
                             "amount": "200.00",
                             "description": "Actualizada",
                             "notes": "Modificada",
                         },
-                    },
+                    ),
+                    _build_transaction_event("deleted", 700, None),
+                ],
+                "transactions_checkpoint_id": 903,
+                "last_confirmed_transaction_id": 850,
+                "has_more_transactions": False,
+                "changes": [
                     {
                         "id": 905,
-                        "movement_id": 700,
-                        "event": "deleted",
-                        "payload": {
-                            "id": 700,
-                            "description": "A borrar",
-                            "deleted": True,
-                        },
-                    },
+                        "movement_id": 1,
+                        "event": "created",
+                        "payload": {"id": 1},
+                    }
                 ],
                 "changes_checkpoint_id": 905,
                 "last_confirmed_change_id": 903,
@@ -105,12 +137,14 @@ def test_sync_billing_transactions_applies_events_and_acknowledges_checkpoint(mo
     ack_calls: dict = {}
 
     def fake_post(url, json, headers, timeout):
-        ack_calls.update({
-            "url": url,
-            "json": json,
-            "headers": headers,
-            "timeout": timeout,
-        })
+        ack_calls.update(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
         expected_feed_url = os.environ["FACTURACION_RUTA_DATA"].rstrip("/")
         assert url == expected_feed_url
         return DummyResponse(
@@ -162,7 +196,7 @@ def test_sync_billing_transactions_applies_events_and_acknowledges_checkpoint(mo
         )
         session.commit()
 
-        result = sync_billing_transactions(limit=2, db=session)
+        result = sync_billing_transactions(limit=3, db=session)
 
         created_tx = session.scalar(
             select(Transaction).where(Transaction.billing_transaction_id == 501)
@@ -192,7 +226,11 @@ def test_sync_billing_transactions_applies_events_and_acknowledges_checkpoint(mo
         assert account.billing_last_changes_confirmed_id == 905
         synced_at = account.billing_synced_at
         assert synced_at is not None
-        assert synced_at.isoformat().startswith("2024-01-04T11:00:00")
+        if synced_at.tzinfo is None:
+            synced_at = synced_at.replace(tzinfo=timezone.utc)
+        else:
+            synced_at = synced_at.astimezone(timezone.utc)
+        assert synced_at == datetime(2024, 1, 4, 11, 0, tzinfo=timezone.utc)
 
         assert result["nuevos"] == 1
         assert result["modificados"] == 1
@@ -203,431 +241,45 @@ def test_sync_billing_transactions_applies_events_and_acknowledges_checkpoint(mo
         )
 
     assert get_calls
-    assert get_calls[0]["params"] == {"limit": 2, "changes_limit": 2, "changes_since": 850}
+    assert get_calls[0]["params"] == {"limit": 3, "changes_limit": 3, "changes_since": 850}
     assert ack_calls["json"] == {
         "movements_checkpoint_id": 903,
         "changes_checkpoint_id": 905,
     }
-    
-    expected_feed_url = os.environ["FACTURACION_RUTA_DATA"].rstrip("/")
-    assert ack_calls["url"] == expected_feed_url
 
 
-def test_sync_billing_transactions_fetches_missing_fields(monkeypatch):
-    os.environ["FACTURACION_RUTA_DATA"] = "https://facturacion.example/api"
-    os.environ["BILLING_API_KEY"] = "secret"
-
-    detail_calls: list[dict] = []
-
-    def fake_get(url, params=None, headers=None, timeout=None):
-        assert headers == {"X-API-Key": "secret"}
-        expected_feed_url = os.environ["FACTURACION_RUTA_DATA"].rstrip("/")
-        if url == expected_feed_url:
-            detail_calls.append({"url": url, "params": params, "headers": headers})
-            return DummyResponse(
-                200,
-                {
-                    "transactions": [
-                        {
-                            "id": 501,
-                            "description": "Solo descripción",
-                        }
-                    ],
-                    "transactions_checkpoint_id": 905,
-                    "last_confirmed_transaction_id": 900,
-                    "changes": [],
-                    "changes_checkpoint_id": None,
-                    "last_confirmed_change_id": 900,
-                },
-            )
-        detail_calls.append({"url": url, "headers": headers, "timeout": timeout})
-        return DummyResponse(
-            200,
-            {
-                "transaction": {
-                    "id": 501,
-                    "date": "2024-02-01",
-                    "amount": "123.45",
-                    "description": "Solo descripción",
-                }
-            },
-        )
-
-    monkeypatch.setattr(httpx, "get", fake_get)
-
-    def fake_post(url, json, headers, timeout):
-        return DummyResponse(
-            200,
-            {
-                "last_transaction_id": 905,
-                "last_change_id": 905,
-                "transactions_updated_at": "2024-02-01T12:00:00Z",
-            },
-        )
-
-    monkeypatch.setattr(httpx, "post", fake_post)
-
-    with db.SessionLocal() as session:
-        account = Account(
-            name="Cuenta facturación",
-            opening_balance=Decimal("0"),
-            currency=Currency.ARS,
-            color="#000000",
-            is_active=True,
-            is_billing=True,
-        )
-        session.add(account)
-        session.commit()
-
-        result = sync_billing_transactions(limit=10, db=session)
-
-        created_tx = session.scalar(
-            select(Transaction).where(Transaction.billing_transaction_id == 501)
-        )
-        assert created_tx is not None
-        assert created_tx.date == date(2024, 2, 1)
-        assert created_tx.amount == Decimal("123.45")
-        assert created_tx.description == "Solo descripción"
-
-        assert result["nuevos"] == 1
-        session.refresh(account)
-        assert account.billing_last_transactions_checkpoint_id == 905
-        assert account.billing_last_transactions_confirmed_id == 905
-    assert len(detail_calls) == 2
-    feed_call = detail_calls[0]
-    expected_feed_url = os.environ["FACTURACION_RUTA_DATA"].rstrip("/")
-    assert feed_call["url"] == expected_feed_url
-    assert feed_call["params"] == {"limit": 10, "changes_limit": 10}
-    assert feed_call["headers"] == {"X-API-Key": "secret"}
-    detail_call = detail_calls[1]
-    assert detail_call["url"] == f"{expected_feed_url}/501"
-    assert detail_call["headers"] == {"X-API-Key": "secret"}
-
-
-def test_sync_billing_transactions_uses_detail_notes_and_preserves_existing(monkeypatch):
-    os.environ["FACTURACION_RUTA_DATA"] = "https://facturacion.example/api"
-    os.environ["BILLING_API_KEY"] = "secret"
-
-    detail_calls: list[dict] = []
-
-    def fake_get(url, params=None, headers=None, timeout=None):
-        assert headers == {"X-API-Key": "secret"}
-        expected_feed_url = os.environ["FACTURACION_RUTA_DATA"].rstrip("/")
-        if url == expected_feed_url:
-            detail_calls.append({"url": url, "params": params, "headers": headers})
-            return DummyResponse(
-                200,
-                {
-                    "transactions": [
-                        {
-                            "id": 800,
-                            "date": "2024-03-10",
-                            "amount": "45.67",
-                            "description": "Generado sin notas",
-                        }
-                    ],
-                    "transactions_checkpoint_id": 921,
-                    "last_confirmed_transaction_id": 910,
-                    "changes": [
-                        {
-                            "id": 921,
-                            "movement_id": 801,
-                            "event": "updated",
-                            "payload": {
-                                "id": 801,
-                                "date": "2024-03-09",
-                                "amount": "89.10",
-                                "description": "Cambio sin notas",
-                            },
-                        }
-                    ],
-                    "changes_checkpoint_id": 921,
-                    "last_confirmed_change_id": 910,
-                },
-            )
-        detail_calls.append({"url": url, "headers": headers, "timeout": timeout})
-        if url == f"{expected_feed_url}/800":
-            return DummyResponse(
-                200,
-                {
-                    "transaction": {
-                        "id": 800,
-                        "date": "2024-03-10",
-                        "amount": "45.67",
-                        "description": "Generado sin notas",
-                        "notes": "Notas del detalle",
-                    }
-                },
-            )
-        if url == f"{expected_feed_url}/801":
-            return DummyResponse(
-                200,
-                {
-                    "transaction": {
-                        "id": 801,
-                        "date": "2024-03-09",
-                        "amount": "89.10",
-                        "description": "Cambio sin notas",
-                    }
-                },
-            )
-        raise AssertionError("detalle inesperado")
-
-    monkeypatch.setattr(httpx, "get", fake_get)
-    monkeypatch.setattr(httpx, "post", lambda *_args, **_kwargs: DummyResponse(200, {"last_change_id": 921}))
-
-    with db.SessionLocal() as session:
-        account = Account(
-            name="Cuenta facturación",
-            opening_balance=Decimal("0"),
-            currency=Currency.ARS,
-            color="#000000",
-            is_active=True,
-            is_billing=True,
-        )
-        session.add(account)
-        session.flush()
-
-        session.add(
-            Transaction(
-                account_id=account.id,
-                date=date(2024, 3, 1),
-                description="Previo",
-                amount=Decimal("89.10"),
-                notes="Notas previas",
-                billing_transaction_id=801,
-            )
-        )
-        session.commit()
-
-        result = sync_billing_transactions(limit=5, db=session)
-
-        created_tx = session.scalar(
-            select(Transaction).where(Transaction.billing_transaction_id == 800)
-        )
-        assert created_tx is not None
-        assert created_tx.notes == "Notas del detalle"
-        assert created_tx.description == "Generado sin notas"
-
-        updated_tx = session.scalar(
-            select(Transaction).where(Transaction.billing_transaction_id == 801)
-        )
-        assert updated_tx is not None
-        assert updated_tx.description == "Cambio sin notas"
-        assert updated_tx.notes == "Notas previas"
-        assert result["nuevos"] == 1
-        assert result["modificados"] == 1
-
-    assert len(detail_calls) == 3
-    expected_feed_url = os.environ["FACTURACION_RUTA_DATA"].rstrip("/")
-    assert detail_calls[0]["url"] == expected_feed_url
-    assert detail_calls[0]["params"] == {"limit": 5, "changes_limit": 5}
-    assert detail_calls[1]["url"] == f"{expected_feed_url}/800"
-    assert detail_calls[2]["url"] == f"{expected_feed_url}/801"
-
-def test_sync_billing_transactions_uses_detail_notes_and_preserves_existing(monkeypatch):
-    os.environ["FACTURACION_RUTA_DATA"] = "https://facturacion.example/api"
-    os.environ["BILLING_API_KEY"] = "secret"
-
-    detail_calls: list[dict] = []
-
-    def fake_get(url, params=None, headers=None, timeout=None):
-        assert headers == {"X-API-Key": "secret"}
-        if url.endswith("/movimientos_cuenta_facturada"):
-            detail_calls.append({"url": url, "params": params, "headers": headers})
-            return DummyResponse(
-                200,
-                {
-                    "transactions": [
-                        {
-                            "id": 800,
-                            "date": "2024-03-10",
-                            "amount": "45.67",
-                            "description": "Generado sin notas",
-                        }
-                    ],
-                    "transactions_checkpoint_id": 921,
-                    "last_confirmed_transaction_id": 910,
-                    "changes": [
-                        {
-                            "id": 921,
-                            "movement_id": 801,
-                            "event": "updated",
-                            "payload": {
-                                "id": 801,
-                                "date": "2024-03-09",
-                                "amount": "89.10",
-                                "description": "Cambio sin notas",
-                            },
-                        }
-                    ],
-                    "changes_checkpoint_id": 921,
-                    "last_confirmed_change_id": 910,
-                },
-            )
-        detail_calls.append({"url": url, "headers": headers, "timeout": timeout})
-        if url.endswith("/800"):
-            return DummyResponse(
-                200,
-                {
-                    "transaction": {
-                        "id": 800,
-                        "date": "2024-03-10",
-                        "amount": "45.67",
-                        "description": "Generado sin notas",
-                        "notes": "Notas del detalle",
-                    }
-                },
-            )
-        if url.endswith("/801"):
-            return DummyResponse(
-                200,
-                {
-                    "transaction": {
-                        "id": 801,
-                        "date": "2024-03-09",
-                        "amount": "89.10",
-                        "description": "Cambio sin notas",
-                    }
-                },
-            )
-        raise AssertionError("detalle inesperado")
-
-    monkeypatch.setattr(httpx, "get", fake_get)
-    monkeypatch.setattr(httpx, "post", lambda *_args, **_kwargs: DummyResponse(200, {"last_change_id": 921}))
-
-    with db.SessionLocal() as session:
-        account = Account(
-            name="Cuenta facturación",
-            opening_balance=Decimal("0"),
-            currency=Currency.ARS,
-            color="#000000",
-            is_active=True,
-            is_billing=True,
-        )
-        session.add(account)
-        session.flush()
-
-        session.add(
-            Transaction(
-                account_id=account.id,
-                date=date(2024, 3, 1),
-                description="Previo",
-                amount=Decimal("89.10"),
-                notes="Notas previas",
-                billing_transaction_id=801,
-            )
-        )
-        session.commit()
-
-        result = sync_billing_transactions(limit=5, db=session)
-
-        created_tx = session.scalar(
-            select(Transaction).where(Transaction.billing_transaction_id == 800)
-        )
-        assert created_tx is not None
-        assert created_tx.notes == "Notas del detalle"
-        assert created_tx.description == "Generado sin notas"
-
-        updated_tx = session.scalar(
-            select(Transaction).where(Transaction.billing_transaction_id == 801)
-        )
-        assert updated_tx is not None
-        assert updated_tx.description == "Cambio sin notas"
-        assert updated_tx.notes == "Notas previas"
-
-        assert result["nuevos"] == 1
-        assert result["modificados"] == 1
-
-    assert len(detail_calls) == 3
-    assert detail_calls[0]["url"].endswith("/movimientos_cuenta_facturada")
-    assert detail_calls[0]["params"] == {"limit": 5, "changes_limit": 5}
-    assert detail_calls[1]["url"].endswith("/movimientos_cuenta_facturada/800")
-    assert detail_calls[2]["url"].endswith("/movimientos_cuenta_facturada/801")
-
-def test_sync_billing_transactions_uses_detail_notes_and_preserves_existing(monkeypatch):
-    os.environ["FACTURACION_RUTA_DATA"] = "https://facturacion.example/api"
+def test_sync_billing_transactions_preserves_existing_notes_when_missing(monkeypatch):
+    os.environ["FACTURACION_RUTA_DATA"] = "https://facturacion.example/api/movimientos_cuenta_facturada"
     os.environ["BILLING_API_KEY"] = "secret"
 
     def fake_get(url, params=None, headers=None, timeout=None):
-        expected_feed_url = os.environ["FACTURACION_RUTA_DATA"].rstrip("/")
-        assert url == expected_feed_url
         assert headers == {"X-API-Key": "secret"}
         return DummyResponse(
             200,
             {
                 "transactions": [],
-                "transactions_checkpoint_id": 910,
-                "last_confirmed_transaction_id": 900,
-                "changes": [
-                    {
-                        "id": 920,
-                        "movement_id": 800,
-                        "event": "created",
-                        "occurred_at": "2024-03-10T09:00:00.000000+00:00",
-                        "payload": {
+                "transaction_events": [
+                    _build_transaction_event(
+                        "updated",
+                        800,
+                        {
                             "id": 800,
                             "date": "2024-03-10",
                             "amount": "45.67",
-                            "description": "Generado sin notas",
+                            "description": "Generado",
                         },
-                    },
-                    {
-                        "id": 921,
-                        "movement_id": 801,
-                        "event": "updated",
-                        "occurred_at": "2024-03-10T10:00:00.000000+00:00",
-                        "payload": {
-                            "id": 801,
-                            "date": "2024-03-09",
-                            "amount": "89.10",
-                            "description": "Cambio sin notas",
-                        },
-                    },
+                    )
                 ],
-                "checkpoint_id": 921,
-                "last_confirmed_id": 910,
-                "has_more": False,
+                "transactions_checkpoint_id": 921,
+                "last_confirmed_transaction_id": 910,
+                "changes": [],
+                "changes_checkpoint_id": 0,
+                "last_confirmed_change_id": 0,
             },
         )
-    ]
-
-    dummy_client = DummyHttpxClient(responses)
-    monkeypatch.setattr(httpx, "Client", lambda *_args, **_kwargs: dummy_client)
-
-    detail_calls: list[dict] = []
-
-    def fake_get(url, headers=None, timeout=None):
-        detail_calls.append({"url": url, "headers": headers, "timeout": timeout})
-        if url.endswith("/800"):
-            return DummyResponse(
-                200,
-                {
-                    "transaction": {
-                        "id": 800,
-                        "date": "2024-03-10",
-                        "amount": "45.67",
-                        "description": "Generado sin notas",
-                        "notes": "Notas del detalle",
-                    }
-                },
-            )
-        if url.endswith("/801"):
-            return DummyResponse(
-                200,
-                {
-                    "transaction": {
-                        "id": 801,
-                        "date": "2024-03-09",
-                        "amount": "89.10",
-                        "description": "Cambio sin notas",
-                    }
-                },
-            )
-        raise AssertionError("detalle inesperado")
 
     monkeypatch.setattr(httpx, "get", fake_get)
-    monkeypatch.setattr(httpx, "post", lambda *_args, **_kwargs: DummyResponse(200, {"last_change_id": 921}))
+    monkeypatch.setattr(httpx, "post", lambda *_args, **_kwargs: DummyResponse(200, {}))
 
     with db.SessionLocal() as session:
         account = Account(
@@ -646,61 +298,90 @@ def test_sync_billing_transactions_uses_detail_notes_and_preserves_existing(monk
                 account_id=account.id,
                 date=date(2024, 3, 1),
                 description="Previo",
-                amount=Decimal("89.10"),
+                amount=Decimal("45.67"),
                 notes="Notas previas",
-                billing_transaction_id=801,
+                billing_transaction_id=800,
             )
         )
         session.commit()
 
-        result = sync_billing_transactions(limit=5, db=session)
-
-        created_tx = session.scalar(
-            select(Transaction).where(Transaction.billing_transaction_id == 800)
-        )
-        assert created_tx is not None
-        assert created_tx.notes == "Notas del detalle"
-        assert created_tx.description == "Generado sin notas"
+        result = sync_billing_transactions(limit=1, db=session)
 
         updated_tx = session.scalar(
-            select(Transaction).where(Transaction.billing_transaction_id == 801)
+            select(Transaction).where(Transaction.billing_transaction_id == 800)
         )
         assert updated_tx is not None
-        assert updated_tx.description == "Cambio sin notas"
+        assert updated_tx.description == "Generado"
         assert updated_tx.notes == "Notas previas"
-
-        assert result["nuevos"] == 1
         assert result["modificados"] == 1
 
-    assert len(detail_calls) == 2
-    assert detail_calls[0]["headers"] == {"X-API-Key": "secret"}
-    assert detail_calls[1]["headers"] == {"X-API-Key": "secret"}
+
+def test_sync_billing_transactions_requires_description(monkeypatch):
+    os.environ["FACTURACION_RUTA_DATA"] = "https://facturacion.example/api/movimientos_cuenta_facturada"
+    os.environ["BILLING_API_KEY"] = "secret"
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        assert headers == {"X-API-Key": "secret"}
+        return DummyResponse(
+            200,
+            {
+                "transactions": [],
+                "transaction_events": [
+                    _build_transaction_event(
+                        "created",
+                        900,
+                        {
+                            "id": 900,
+                            "date": "2024-04-01",
+                            "amount": "99.99",
+                        },
+                    )
+                ],
+                "transactions_checkpoint_id": 930,
+                "last_confirmed_transaction_id": 920,
+                "changes": [],
+                "changes_checkpoint_id": 0,
+                "last_confirmed_change_id": 0,
+            },
+        )
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    monkeypatch.setattr(httpx, "post", lambda *_args, **_kwargs: DummyResponse(200, {}))
+
+    with db.SessionLocal() as session:
+        account = Account(
+            name="Cuenta facturación",
+            opening_balance=Decimal("0"),
+            currency=Currency.ARS,
+            color="#000000",
+            is_active=True,
+            is_billing=True,
+        )
+        session.add(account)
+        session.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            sync_billing_transactions(limit=1, db=session)
+
+        assert exc_info.value.status_code == status.HTTP_502_BAD_GATEWAY
+
 
 def test_sync_billing_transactions_fails_when_deleting_missing_transaction(monkeypatch):
-    os.environ["FACTURACION_RUTA_DATA"] = "https://facturacion.example/api"
+    os.environ["FACTURACION_RUTA_DATA"] = "https://facturacion.example/api/movimientos_cuenta_facturada"
     os.environ["BILLING_API_KEY"] = "secret"
 
     def fake_get(url, params=None, headers=None, timeout=None):
-        assert url.endswith("/movimientos_cuenta_facturada")
         assert headers == {"X-API-Key": "secret"}
         return DummyResponse(
             200,
             {
                 "transactions": [],
+                "transaction_events": [
+                    _build_transaction_event("deleted", 1234, None)
+                ],
                 "transactions_checkpoint_id": 910,
                 "last_confirmed_transaction_id": 900,
-                "changes": [
-                    {
-                        "id": 910,
-                        "movement_id": 1234,
-                        "event": "deleted",
-                        "payload": {
-                            "id": 1234,
-                            "description": "Desconocido",
-                            "deleted": True,
-                        },
-                    }
-                ],
+                "changes": [],
                 "changes_checkpoint_id": 910,
                 "last_confirmed_change_id": 900,
             },
@@ -734,3 +415,20 @@ def test_sync_billing_transactions_fails_when_deleting_missing_transaction(monke
         session.refresh(account)
         assert account.billing_last_transactions_checkpoint_id == 800
         assert account.billing_last_transactions_confirmed_id is None
+
+
+def test_sync_billing_transactions_requires_billing_account(monkeypatch):
+    os.environ["FACTURACION_RUTA_DATA"] = "https://facturacion.example/api/movimientos_cuenta_facturada"
+    os.environ["BILLING_API_KEY"] = "secret"
+
+    monkeypatch.setattr(
+        httpx,
+        "get",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("GET no esperado")),
+    )
+
+    with db.SessionLocal() as session:
+        with pytest.raises(HTTPException) as exc_info:
+            sync_billing_transactions(limit=1, db=session)
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary
- update billing sync to consume transaction event payloads instead of per-movement detail lookups
- validate exportable change payloads only for checkpoint confirmation and tighten required fields
- rewrite billing sync test suite to cover the new contract expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd2509fa1083328cb5f1ea18ffdbb1