### PR TITLE
Add backend-driven pagination for transactions table

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -35,6 +35,13 @@
         <tbody></tbody>
       </table>
     </div>
+    <div id="tx-pagination" class="d-flex flex-column flex-md-row align-items-center justify-content-between gap-2 py-3">
+      <span id="tx-pagination-summary" class="text-muted">Cargando movimientos...</span>
+      <div class="btn-group" role="group" aria-label="Paginación de movimientos">
+        <button type="button" class="btn btn-outline-secondary" id="tx-pagination-prev" disabled>Anterior</button>
+        <button type="button" class="btn btn-outline-secondary" id="tx-pagination-next" disabled>Siguiente</button>
+      </div>
+    </div>
   </div>
   <div class="modal fade" id="txFilterModal" tabindex="-1" aria-labelledby="tx-filter-title">
     <div class="modal-dialog">


### PR DESCRIPTION
## Summary
- request transactions by page from the backend and propagate new response shape in the JS API helper
- replace infinite scroll with explicit pagination controls and server-driven reloading for search and filters
- render paginated results in the table and refresh state after create, delete, and billing sync actions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de949f603883329335e1b10ac1df38